### PR TITLE
Add side car to the database migration script

### DIFF
--- a/charts/deps/Chart.yaml
+++ b/charts/deps/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.13
+version: 0.0.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openmetadata/Chart.yaml
+++ b/charts/openmetadata/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.13
+version: 0.0.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openmetadata/templates/check-db-migrations-job-hook.yaml
+++ b/charts/openmetadata/templates/check-db-migrations-job-hook.yaml
@@ -79,6 +79,9 @@ spec:
         {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- if .Values.sidecars }}
+        {{- include "tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 6 }}
+      {{- end }}
       restartPolicy: Never
       volumes:
       - name: migration-script


### PR DESCRIPTION

* The sidecar container has added to the Deployment object, and it should also be added to the database migration script as well.
* We use sidecar container to host database auth proxy, which it helps us achieving more convenient TLS setup and access control.
* In all K8S objects where the OMD MySQL database is accessed, the sidecar container should be available.