### PR TITLE
bumped chart version for deps as well

### DIFF
--- a/charts/deps/Chart.yaml
+++ b/charts/deps/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.40
+version: 0.0.41
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Missed sync-ing chart version as part of the previous [PR](https://github.com/open-metadata/openmetadata-helm-charts/pull/86) which fixed [ISSUE-87](https://github.com/open-metadata/openmetadata-helm-charts/issues/87)

@harshach 