### PR TITLE
updated missed elasticsearch truststore config in db migration hook too

### DIFF
--- a/charts/deps/Chart.yaml
+++ b/charts/deps/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.41
+version: 0.0.42
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openmetadata/Chart.yaml
+++ b/charts/openmetadata/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.41
+version: 0.0.42
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openmetadata/templates/check-db-migrations-job-hook.yaml
+++ b/charts/openmetadata/templates/check-db-migrations-job-hook.yaml
@@ -95,10 +95,10 @@ spec:
                 key: {{ .password.secretKey }}
           {{- end }}
           {{- end }}
-          {{- if .Values.global.elasticsearch.trustStore.enabled -}}
+          {{- if .Values.global.elasticsearch.trustStore.enabled }}
           - name: ELASTICSEARCH_TRUST_STORE_PATH
             value: {{.Values.global.elasticsearch.trustStore.path }}
-          {{- with .Values.global.elasticsearch.trustStore.password }}
+          {{- with .Values.global.elasticsearch.trustStore }}
           - name: ELASTICSEARCH_TRUST_STORE_PASSWORD
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
### Describe your changes :
This applies the same fix for elasticsearch truststore config as done in [this previous PR](https://github.com/open-metadata/openmetadata-helm-charts/pull/86), but in the db migration hook. Chart version bump is required in both Chart.yamls.

#
### Type of change :
- [x] Bug fix


#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [x] All new and existing tests passed.

#
### Reviewers
@harshach