### PR TITLE
fix: revert mysql deps to 8.8.23

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Add Helm repos
         run: |
           helm repo add elasticsearch https://helm.elastic.co
-          helm repo add mysql https://charts.bitnami.com/bitnami
+          helm repo add mysql https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
           helm repo add airflow https://airflow-helm.github.io/charts
 
       - uses: actions/setup-python@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Add Helm repos
         run: |
           helm repo add elasticsearch https://helm.elastic.co
-          helm repo add mysql https://charts.bitnami.com/bitnami
+          helm repo add mysql https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
           helm repo add airflow https://airflow-helm.github.io/charts
 
       - name: Run chart-releaser

--- a/charts/deps/Chart.lock
+++ b/charts/deps/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: mysql
-  repository: https://charts.bitnami.com/bitnami
-  version: 9.2.1
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+  version: 8.8.23
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.10.2
 - name: airflow
   repository: https://airflow-helm.github.io/charts
   version: 8.6.1
-digest: sha256:3507cbe457c8a3f7d33d66a354b612f14a9d876dea3e0b787cd9aadf9c8e5175
-generated: "2022-12-22T12:58:27.817058+05:30"
+digest: sha256:69ca7632aa4e00b14d164572d6e1a97b89069bf6e78d8961e7d58aa3c0c4c790
+generated: "2023-01-05T19:14:37.793166+05:30"

--- a/charts/deps/Chart.yaml
+++ b/charts/deps/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.50
+version: 0.0.51
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -59,8 +59,8 @@ icon: https://open-metadata.org/images/favicon.png
 # Add Dependencies of other charts
 dependencies:
 - name: mysql
-  version: "9.2.1"
-  repository: "https://charts.bitnami.com/bitnami"
+  version: "8.8.23"
+  repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
   condition: mysql.enabled
 - name: elasticsearch
   version: "7.10.2"

--- a/charts/openmetadata/Chart.yaml
+++ b/charts/openmetadata/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.50
+version: 0.0.51
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
As per the Bitnami Repository Index change as mentioned [here](https://github.com/bitnami/charts/issues/10833), we are reverting the helm chart dependency usage back to 8.8.23 for now.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @shahsank3t -->
<!--- @sureshms @harshach -->
<!--- @ayush-shah @akash-jain-10 -->