### PR TITLE
[fixed] db-migrations-job did not have spec.serviceAccountName

### DIFF
--- a/charts/openmetadata/templates/check-db-migrations-job-hook.yaml
+++ b/charts/openmetadata/templates/check-db-migrations-job-hook.yaml
@@ -1,4 +1,3 @@
-# unnecessary commit to force GitHub to update the PR
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/openmetadata/templates/check-db-migrations-job-hook.yaml
+++ b/charts/openmetadata/templates/check-db-migrations-job-hook.yaml
@@ -25,6 +25,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ include "OpenMetadata.serviceAccountName" . }}
       containers:
       - command:
         - /bin/bash

--- a/charts/openmetadata/templates/check-db-migrations-job-hook.yaml
+++ b/charts/openmetadata/templates/check-db-migrations-job-hook.yaml
@@ -1,3 +1,4 @@
+# unnecessary commit to force GitHub to update the PR
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
### Describe your changes :

The `db-migrations-job` chart didn't have a parameterized `spec.serviceAccountName` field and as a result, db migrations couldn't authenticate using a serviceAccount.

When I added it with the correct value to my own deployment, the migrations ran w/out error, so this seems to be a complete fix.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
n/a

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [x] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests passed.

#
### Reviewers
@sureshms @harshach