### PR TITLE
Provide option to configure smtp sender mail address

### DIFF
--- a/charts/deps/Chart.yaml
+++ b/charts/deps/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.57
+version: 0.0.58
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openmetadata/Chart.yaml
+++ b/charts/openmetadata/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.57
+version: 0.0.58
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openmetadata/README.md
+++ b/charts/openmetadata/README.md
@@ -118,6 +118,7 @@ This is achieved by Helm Hooks currently.
 | global.smtpConfig.supportUrl | string | `https://slack.open-metadata.org` |
 | global.smtpConfig.transportationStrategy | string | `SMTP_TLS` |
 | global.smtpConfig.username | string | `Empty String` |
+| global.smtpConfig.senderMail | string | `Empty String` |
 
 
 ## Chart Values

--- a/charts/openmetadata/templates/deployment.yaml
+++ b/charts/openmetadata/templates/deployment.yaml
@@ -234,6 +234,8 @@ spec:
           {{- end }}
           - name: SMTP_SERVER_STRATEGY
             value: "{{ .Values.global.smtpConfig.transportationStrategy }}"
+          - name: OPENMETADATA_SMTP_SENDER_MAIL
+            value: "{{ .Values.global.smtpConfig.senderMail }}"
           {{- end }}
           {{- with .Values.extraEnvs }}
             {{- toYaml . | nindent 10 }}

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -393,6 +393,9 @@
                                 }
                             }
                         },
+                        "senderMail": {
+                            "type": "string"
+                        },
                         "serverEndpoint": {
                             "type": "string"
                         },

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -111,6 +111,7 @@ global:
     openMetadataUrl: ""
     serverEndpoint: ""
     serverPort: ""
+    senderMail: ""
     username: ""
     password:
       secretRef: ""


### PR DESCRIPTION
### Describe your changes :

Currently, there's no inbuilt config parameter to set the smtp sender mail address. This could be worked around using the `extraEnvs`, but providing an option under the smtp config directly seemed helpful.

If the sender mail values is not provided, we get the following error during sign-up (when we expect a verification email to be sent):

![Screenshot](https://user-images.githubusercontent.com/7802795/231968150-51682dca-1b00-4ae7-82fc-ab6813ad4036.png)


#
### Type of change :
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [x] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @shahsank3t -->
<!--- @sureshms @harshach -->
<!--- @ayush-shah @akash-jain-10 -->