### PR TITLE
Add template with airflow dep structure

### DIFF
--- a/charts/deps/Chart.yaml
+++ b/charts/deps/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/deps/files/pod_template.kubernetes-helm-yaml
+++ b/charts/deps/files/pod_template.kubernetes-helm-yaml
@@ -1,0 +1,89 @@
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values.airflow "nodeSelector" .Values.airflow.airflow.kubernetesPodTemplate.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values.airflow "affinity" .Values.airflow.airflow.kubernetesPodTemplate.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values.airflow "tolerations" .Values.airflow.airflow.kubernetesPodTemplate.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values.airflow "securityContext" .Values.airflow.airflow.kubernetesPodTemplate.securityContext) }}
+{{- $extraPipPackages := .Values.airflow.airflow.kubernetesPodTemplate.extraPipPackages }}
+{{- $extraVolumeMounts := .Values.airflow.airflow.kubernetesPodTemplate.extraVolumeMounts }}
+{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values.airflow "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
+{{- $extraVolumes := .Values.airflow.airflow.kubernetesPodTemplate.extraVolumes }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values.airflow "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy-name
+  {{- if .Values.airflow.airflow.kubernetesPodTemplate.podAnnotations }}
+  annotations:
+    {{- toYaml .Values.airflow.airflow.kubernetesPodTemplate.podAnnotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.airflow.airflow.kubernetesPodTemplate.podLabels }}
+  labels:
+    {{- toYaml .Values.airflow.airflow.kubernetesPodTemplate.podLabels | nindent 4 }}
+  {{- end }}
+spec:
+  restartPolicy: Never
+  {{- if .Values.airflow.airflow.image.pullSecret }}
+  imagePullSecrets:
+    - name: {{ .Values.airflow.airflow.image.pullSecret }}
+  {{- end }}
+  serviceAccountName: airflow
+  shareProcessNamespace: {{ .Values.airflow.airflow.kubernetesPodTemplate.shareProcessNamespace }}
+  {{- if $podNodeSelector }}
+  nodeSelector:
+    {{- $podNodeSelector | nindent 4 }}
+  {{- end }}
+  {{- if $podAffinity }}
+  affinity:
+    {{- $podAffinity | nindent 4 }}
+  {{- end }}
+  {{- if $podTolerations }}
+  tolerations:
+    {{- $podTolerations | nindent 4 }}
+  {{- end }}
+  {{- if $podSecurityContext }}
+  securityContext:
+    {{- $podSecurityContext | nindent 4 }}
+  {{- end }}
+  {{- if or ($extraPipPackages) (.Values.airflow.airflow.kubernetesPodTemplate.extraInitContainers) }}
+  initContainers:
+    {{- if $extraPipPackages }}
+    {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values.airflow "extraPipPackages" $extraPipPackages) | indent 4 }}
+    {{- end }}
+    {{- if .Values.airflow.airflow.kubernetesPodTemplate.extraInitContainers }}
+    {{- toYaml .Values.airflow.airflow.kubernetesPodTemplate.extraInitContainers | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  containers:
+    - name: base
+      image: {{ .Values.airflow.airflow.image.repository }}:{{ .Values.airflow.airflow.image.tag }}
+      imagePullPolicy: {{ .Values.airflow.airflow.image.pullPolicy }}
+      securityContext:
+        runAsUser: {{ .Values.airflow.airflow.image.uid }}
+        runAsGroup: {{ .Values.airflow.airflow.image.gid }}
+      envFrom:
+        - secretRef:
+            name: {{ include "airflow.fullname" . }}-config-envs
+      env:
+        ## KubernetesExecutor Pods use LocalExecutor internally
+        - name: AIRFLOW__CORE__EXECUTOR
+          value: LocalExecutor
+        {{- /* NOTE: the FIRST definition of an `env` takes precedence (so we include user-defined `env` LAST) */ -}}
+        {{- /* NOTE: we set `CONNECTION_CHECK_MAX_COUNT=20` to enable airflow's `/entrypoint` db connection check */ -}}
+        {{- include "airflow.env" (dict "Release" .Release "Values" .Values.airflow "CONNECTION_CHECK_MAX_COUNT" "20")  | indent 8 }}
+      ports: []
+      command: []
+      args: []
+      {{- if .Values.airflow.airflow.kubernetesPodTemplate.resources }}
+      resources:
+        {{- toYaml .Values.airflow.airflow.kubernetesPodTemplate.resources | nindent 8 }}
+      {{- end }}
+      {{- if $volumeMounts }}
+      volumeMounts:
+        {{- $volumeMounts | indent 8 }}
+      {{- end }}
+    {{- if .Values.airflow.airflow.kubernetesPodTemplate.extraContainers }}
+    {{- toYaml .Values.airflow.airflow.kubernetesPodTemplate.extraContainers | nindent 4 }}
+    {{- end }}
+  {{- if $volumes }}
+  volumes:
+    {{- $volumes | indent 4 }}
+  {{- end }}

--- a/charts/deps/templates/configmap-pod-template.yaml
+++ b/charts/deps/templates/configmap-pod-template.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openmetadata-pod-template
+  labels:
+    app: {{ include "airflow.labels.app" . }}
+    chart: {{ include "airflow.labels.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  pod_template.yaml: |-
+    {{- if .Values.airflow.airflow.kubernetesPodTemplate.stringOverride }}
+    {{- .Values.airflow.airflow.kubernetesPodTemplate.stringOverride | nindent 4 }}
+    {{- else }}
+    {{- tpl (.Files.Get "files/pod_template.kubernetes-helm-yaml") . | nindent 4 }}
+    {{- end }}

--- a/charts/deps/templates/configmap-pod-template.yaml
+++ b/charts/deps/templates/configmap-pod-template.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.airflow.airflow.executor "KubernetesExecutor") (eq .Values.airflow.airflow.executor "CeleryKubernetesExecutor") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,3 +15,4 @@ data:
     {{- else }}
     {{- tpl (.Files.Get "files/pod_template.kubernetes-helm-yaml") . | nindent 4 }}
     {{- end }}
+{{- end -}}

--- a/charts/deps/values.yaml
+++ b/charts/deps/values.yaml
@@ -74,6 +74,15 @@ airflow:
       firstName: Peter
       lastName: Parker
   web:
+    extraVolumes:
+    - name: pod-template
+      configMap:
+        name: openmetadata-pod-template
+        defaultMode: 420
+    extraVolumeMounts:
+      - name: pod-template
+        readOnly: true
+        mountPath: /opt/airflow/pod_templates/
     readinessProbe:
       enabled: true
       initialDelaySeconds: 360

--- a/charts/deps/values.yaml
+++ b/charts/deps/values.yaml
@@ -82,7 +82,8 @@ airflow:
     extraVolumeMounts:
       - name: pod-template
         readOnly: true
-        mountPath: /opt/airflow/pod_templates/
+        subPath: pod_template.yaml
+        mountPath: /opt/airflow/pod_templates/pod_template.yaml
     readinessProbe:
       enabled: true
       initialDelaySeconds: 360

--- a/charts/openmetadata/Chart.yaml
+++ b/charts/openmetadata/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -130,7 +130,7 @@ global:
       sp:
         entityId: "http://openmetadata.default.svc.cluster.local:8585/api/v1/saml/metadata"
         acs: "http://openmetadata.default.svc.cluster.local:8585/api/v1/saml/acs"
-        spX509Certificate: 
+        spX509Certificate:
           secretRef: ""
           secretKey: ""
         callback: "http://openmetadata.default.svc.cluster.local:8585/saml/callback"
@@ -147,7 +147,7 @@ global:
         keyStoreFilePath: ""
         keyStoreAlias:
           secretRef: ""
-          secretKey: ""          
+          secretKey: ""
         keyStorePassword:
           secretRef: ""
           secretKey: ""


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->

We are replicating the configMap structure for the pod_template_file and passing it as a constant name to the webserver.

This will create the `pod_template.yaml` file in the webserver regardless of the deployment name of the charts, which was the initial issue.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @shahsank3t -->
<!--- @sureshms @harshach -->
<!--- @ayush-shah @akash-jain-10 -->