### PR TITLE
Apply security context to chart test

### DIFF
--- a/charts/openmetadata/templates/tests/test-connection.yaml
+++ b/charts/openmetadata/templates/tests/test-connection.yaml
@@ -8,8 +8,12 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
+  securityContext:
+    {{- toYaml .Values.podSecurityContext | nindent 4 }}
   containers:
     - name: wget
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       image: busybox
       command: ['wget']
       args: ['{{ include "OpenMetadata.fullname" . }}:{{ .Values.service.port }}']


### PR DESCRIPTION
### Describe your changes :
In our Kubernetes setup we use Polaris to enforce several best practices. This blocks the execution of the helm chart test because the required security context configuration is not present. This PR adds the security context configuration which is already defined in `values.yaml` to the helm chart test.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] My changes generate no new warnings.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @shahsank3t -->
<!--- @sureshms @harshach -->
@akash-jain-10