### PR TITLE
Allow additional properties in global

### DIFF
--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -23,7 +23,7 @@
         },
         "global": {
             "type": "object",
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
                 "pipelineServiceClientConfig": {
                     "type": "object",
@@ -247,7 +247,7 @@
                               },
                               "idp": {
                                 "type": "object",
-                                "additionalProperties": false,                                
+                                "additionalProperties": false,
                                 "properties": {
                                   "entityId": {
                                     "type": "string"
@@ -295,7 +295,7 @@
                                         "type": "string"
                                       }
                                     }
-                                  },                                  
+                                  },
                                   "callback": {
                                     "type": "string"
                                   }


### PR DESCRIPTION
### Describe your changes :
Because the openmetadata chart is using the special `global` values and is not allowing any additional properties in the json schema this chart can effectively not be used as a dependency of a chart that also uses these special `global` values. The correct way to resolve this is to not use `global` and I see that an effort is being made in #143. Allowing additional values is an intermediate, non-breaking step to allow this chart to be used as a dependency (at the cost of not checking for additional properties within the first level of `global`).

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] My changes generate no new warnings.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
@akash-jain-10