### PR TITLE
Add ES RestHighLevelClient TCP keep alive timeout

### DIFF
--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -501,6 +501,9 @@
                         "host": {
                             "type": "string"
                         },
+                        "keepAliveTimeoutSecs": {
+                            "type": "integer"
+                        },
                         "port": {
                             "type": "integer"
                         },

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -22,6 +22,7 @@ global:
     scheme: http
     connectionTimeoutSecs: 5
     socketTimeoutSecs: 60
+    keepAliveTimeoutSecs: 600
     batchSize: 10
     searchIndexMappingLanguage: "EN"
     trustStore:


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->

When openmetadata app has been idle for a while, calling any search method of an ElasticsearchRepository (which uses the RestHighLevelClient for the underlying ES connection) results in a java.io.IOException: Connection reset by peer.

This pull request enable TCP keep alive strategy.

See relative pull request, https://github.com/open-metadata/OpenMetadata/pull/11731

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [] Bug fix
- [x] Improvement
- [x] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @shahsank3t -->
<!--- @sureshms @harshach -->
<!--- @ayush-shah @akash-jain-10 -->