### PR TITLE
fix: enable saml keystore configs only on wantAssertionEncrypted or wantNameIdEncrypted

### DIFF
--- a/charts/openmetadata/templates/deployment.yaml
+++ b/charts/openmetadata/templates/deployment.yaml
@@ -235,6 +235,8 @@ spec:
             value: "{{ .Values.global.authentication.saml.security.wantAssertionEncrypted }}"
           - name: SAML_WANT_NAME_ID_ENCRYPTED
             value: "{{ .Values.global.authentication.saml.security.wantNameIdEncrypted }}"
+          {{- if or .Values.global.authentication.saml.security.wantAssertionEncrypted .Values.global.authentication.saml.security.wantNameIdEncrypted }}
+          # Key Store should only be considered if either wantAssertionEncrypted or wantNameIdEncrypted will be true
           - name: SAML_KEYSTORE_FILE_PATH
             value: "{{ .Values.global.authentication.saml.security.keyStoreFilePath }}"
           {{- with .Values.global.authentication.saml.security.keyStoreAlias }}
@@ -252,7 +254,7 @@ spec:
                 key: {{ .secretKey }}
           {{- end }}
           {{- end }}
-
+          {{- end }}
           - name: ELASTICSEARCH_HOST
             value: "{{ .Values.global.elasticsearch.host }}"
           - name: ELASTICSEARCH_PORT


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->

Enable saml keystore configs only on wantAssertionEncrypted or wantNameIdEncrypted

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @shahsank3t -->
<!--- @sureshms @harshach -->
<!--- @ayush-shah @akash-jain-10 -->