### PR TITLE
[FEAT] Add support for ServiceMonitor to grab prometheus metrics

### DIFF
--- a/charts/openmetadata/README.md
+++ b/charts/openmetadata/README.md
@@ -220,6 +220,9 @@ helm install openmetadata open-metadata/openmetadata --values <<path-to-values-f
 | serviceAccount.annotations | object | `{}` |
 | serviceAccount.create | bool | `true` |
 | serviceAccount.name | string | `nil` |
+| serviceMonitor.annotations | object | `{}` |
+| serviceMonitor.enabled | bool | `false` |
+| serviceMonitor.interval | string | `30s` |
 | sidecars | list | `[]` |
 | startupProbe.periodSeconds | int | `60` |
 | startupProbe.failureThreshold | int | `5` |

--- a/charts/openmetadata/templates/servicemonitor.yaml
+++ b/charts/openmetadata/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "OpenMetadata.fullname" . }}
+  labels:
+    {{- include "OpenMetadata.labels" . | indent 4 }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "OpenMetadata.selectorLabels" . | indent 6 }}
+  endpoints:
+    - port: http-admin
+      path: /prometheus
+      interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -286,6 +286,12 @@ service:
   adminPort: 8586
   annotations: {}
 
+# Service monitor for Prometheus metrics
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  annotations: {}
+
 ingress:
   enabled: false
   className: ""


### PR DESCRIPTION
### Describe your changes :
Added support for creating ServiceMetrics resources using the Open Metadata helm chart so users can collect prometheus metrics using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator).

#
### Type of change :
- [x] New feature
- [x] Documentation

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@harshach 
@akash-jain-10 
@Anuj359 
@dhruvinmaniar123 