### PR TITLE
[FEAT] Allow envFrom in OM deployment

### DIFF
--- a/charts/openmetadata/templates/deployment.yaml
+++ b/charts/openmetadata/templates/deployment.yaml
@@ -68,6 +68,10 @@ spec:
           {{- with .Values.extraEnvs }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.sidecars }}

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -12,6 +12,9 @@
         "extraEnvs": {
             "type": "array"
         },
+        "envFrom": {
+            "type": "array"
+        },
         "extraInitContainers": {
             "type": "array"
         },

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -311,6 +311,10 @@ extraEnvs: []
 # - name: MY_ENVIRONMENT_VAR
 #   value: the_value_goes_here
 
+envFrom: []
+# - secretRef:
+#     name: secret_containing_config
+
 extraVolumes: []
 # - name: extras
 #   emptyDir: {}


### PR DESCRIPTION
### Describe your changes :
Added support for `envFrom` statement in the app deployment.
With this feature, users will be able to define multiple environment variables in a single secret.

### Type of change :
- [x] Improvement
- [x] New feature
- [x] Documentation

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] All new and existing tests passed.

#
### Reviewers
@akash-jain-10 