### PR TITLE
fix: ElasticSearch esJavaOpts bump to use 1 GiB RAM

### DIFF
--- a/charts/deps/values.yaml
+++ b/charts/deps/values.yaml
@@ -38,7 +38,7 @@ elasticsearch:
   minimumMasterNodes: 1
   fullnameOverride: "elasticsearch"
   imagePullPolicy: "Always"
-  esJavaOpts: "-Xmx128m -Xms128m"
+  esJavaOpts: "-Xmx1024m -Xms1024m"
   maxUnavailable: 0
   clusterHealthCheckParams: "wait_for_status=yellow&timeout=20s"
   resources:


### PR DESCRIPTION
ElasticSearch esJavaOpts bump to use 1 GiB RAM.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @shahsank3t -->
<!--- @sureshms @harshach -->
<!--- @ayush-shah @akash-jain-10 -->