### PR TITLE
Upgrade: airflow base image from 2.5.3 to 2.6.3

### DIFF
--- a/charts/deps/Chart.yaml
+++ b/charts/deps/Chart.yaml
@@ -68,6 +68,6 @@ dependencies:
   repository: "https://helm.elastic.co"
   condition: elasticsearch.enabled
 - name: airflow
-  version: "8.7.1"
+  version: "8.8.0"
   repository: "https://airflow-helm.github.io/charts"
   condition: airflow.enabled


### PR DESCRIPTION
Upgrading the airflow base image from 2.5.3 to 2.6.3