### PR TITLE
add semversion condition

### DIFF
--- a/charts/openmetadata/templates/deployment.yaml
+++ b/charts/openmetadata/templates/deployment.yaml
@@ -73,8 +73,10 @@ spec:
             {{ .Values.livenessProbe | toYaml | indent 12 | trim }}
           readinessProbe:
             {{ .Values.readinessProbe | toYaml | indent 12 | trim }}
+{{- if (semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion) }}
           startupProbe:
             {{ .Values.startupProbe | toYaml | indent 12 | trim }}
+{{- end }}
           env:
           {{- include "OpenMetadata.configs" . | nindent 10 }}
           {{- with .Values.extraEnvs }}


### PR DESCRIPTION
### Describe your changes :
I added semverCompare condition in the deployment template because the attribute of startupProbe doesn't work for kubernetes version that is below <1.16-0 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [x] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
@shahsank3t 
@harshach 

<!--- @shahsank3t -->
<!--- @sureshms @harshach -->
<!--- @ayush-shah @akash-jain-10 -->