### PR TITLE
feat: unified approach for secrets referencing (and disabling)

### DIFF
--- a/charts/openmetadata/templates/_helpers.tpl
+++ b/charts/openmetadata/templates/_helpers.tpl
@@ -60,7 +60,7 @@ Create the name of the service account to use
 {{- if .Values.serviceAccount.create }}
 {{- default (include "OpenMetadata.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- default "default" (tpl .Values.serviceAccount.name .) }}
 {{- end }}
 {{- end }}
 
@@ -104,6 +104,7 @@ OpenMetadata Configurations Environment Variables*/}}
     secretKeyRef:
       name: {{ .secretRef }}
       key: {{ .secretKey }}
+{{- end }}
 {{ else }}
 - name: FERNET_KEY
   valueFrom:

--- a/charts/openmetadata/templates/_helpers.tpl
+++ b/charts/openmetadata/templates/_helpers.tpl
@@ -97,7 +97,7 @@ Warning to update openmetadata global keyword to openmetadata.config */}}
 {{/*
 OpenMetadata Configurations Environment Variables*/}}
 {{- define "OpenMetadata.configs" -}}
-{{- if .Values.openmetadata.config.fernetkey.secretRef }}
+{{- if .Values.openmetadata.config.fernetkey.secretRef -}}
 {{- with .Values.openmetadata.config.fernetkey -}}
 - name: FERNET_KEY
   valueFrom:
@@ -315,7 +315,6 @@ OpenMetadata Configurations Environment Variables*/}}
 {{- end }}
 {{- end }}
 {{- end }}
-{{- end }}
 - name: ELASTICSEARCH_HOST
   value: "{{ .Values.openmetadata.config.elasticsearch.host }}"
 - name: SEARCH_TYPE
@@ -338,7 +337,6 @@ OpenMetadata Configurations Environment Variables*/}}
     secretKeyRef:
       name: {{ .password.secretRef }}
       key: {{ .password.secretKey }}
-{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -396,7 +394,6 @@ OpenMetadata Configurations Environment Variables*/}}
     secretKeyRef:
       name: {{ .password.secretRef }}
       key: {{ .password.secretKey }}
-{{- end }}
 {{- end }}
 {{- end }}
 - name: PIPELINE_SERVICE_CLIENT_VERIFY_SSL

--- a/charts/openmetadata/templates/_helpers.tpl
+++ b/charts/openmetadata/templates/_helpers.tpl
@@ -315,6 +315,7 @@ OpenMetadata Configurations Environment Variables*/}}
 {{- end }}
 {{- end }}
 {{- end }}
+{{- end }}
 - name: ELASTICSEARCH_HOST
   value: "{{ .Values.openmetadata.config.elasticsearch.host }}"
 - name: SEARCH_TYPE
@@ -337,6 +338,7 @@ OpenMetadata Configurations Environment Variables*/}}
     secretKeyRef:
       name: {{ .password.secretRef }}
       key: {{ .password.secretKey }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -396,6 +398,7 @@ OpenMetadata Configurations Environment Variables*/}}
       key: {{ .password.secretKey }}
 {{- end }}
 {{- end }}
+{{- end }}
 - name: PIPELINE_SERVICE_CLIENT_VERIFY_SSL
   value: "{{ .Values.openmetadata.config.pipelineServiceClientConfig.verifySsl }}"
 - name: PIPELINE_SERVICE_CLIENT_HOST_IP
@@ -412,7 +415,7 @@ OpenMetadata Configurations Environment Variables*/}}
 {{- if .Values.openmetadata.config.secretsManager.additionalParameters.enabled }}
 - name: OM_SM_REGION
   value: "{{ .Values.openmetadata.config.secretsManager.additionalParameters.region }}"
-{{- if .Values.openmetadata.config.secretsManager.additionalParameters.accessKeyId.secretRef }}
+{{- if .Values.openmetadata.config.secretsManager.additionalParameters.accessKeyId.secretRef -}}
 {{- with .Values.openmetadata.config.secretsManager.additionalParameters.accessKeyId }}
 - name: OM_SM_ACCESS_KEY_ID
   valueFrom:
@@ -498,4 +501,5 @@ OpenMetadata Configurations Environment Variables*/}}
   value: "{{ .Values.openmetadata.config.web.permissionPolicy.enabled }}"
 - name: WEB_CONF_PERMISSION_POLICY_OPTION
   value: "{{ .Values.openmetadata.config.web.permissionPolicy.option }}"
+
 {{- end }}

--- a/charts/openmetadata/templates/_helpers.tpl
+++ b/charts/openmetadata/templates/_helpers.tpl
@@ -88,7 +88,7 @@ command:
 {{- end }}
 {{- end }}
 
-{{/* 
+{{/*
 Warning to update openmetadata global keyword to openmetadata.config */}}
 {{- define "error-message" }}
 {{- printf "Error: %s" . | fail }}
@@ -98,16 +98,17 @@ Warning to update openmetadata global keyword to openmetadata.config */}}
 OpenMetadata Configurations Environment Variables*/}}
 {{- define "OpenMetadata.configs" -}}
 {{- if .Values.openmetadata.config.fernetkey.secretRef -}}
+{{- with .Values.openmetadata.config.fernetkey -}}
 - name: FERNET_KEY
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.openmetadata.config.fernetkey.secretRef }}
-      key: {{ .Values.openmetadata.config.fernetkey.secretKey }}
+      name: {{ .secretRef }}
+      key: {{ .secretKey }}
 {{ else }}
 - name: FERNET_KEY
   valueFrom:
     secretKeyRef:
-      name: {{ include "OpenMetadata.fullname" . }}-secret 
+      name: {{ include "OpenMetadata.fullname" . }}-secret
       key: FERNET_KEY
 {{- end }}
 - name: MIGRATION_EXTENSION_PATH
@@ -123,7 +124,7 @@ OpenMetadata Configurations Environment Variables*/}}
 - name: MASK_PASSWORDS_API
   value: '{{ .Values.openmetadata.config.maskPasswordsApi }}'
 - name: OPENMETADATA_CLUSTER_NAME
-  value: "{{ .Values.openmetadata.config.clusterName }}"
+  value: "{{ tpl .Values.openmetadata.config.clusterName . }}"
 - name: OM_URI
   value: "{{ .Values.openmetadata.config.openmetadata.uri }}"
 - name: LOG_LEVEL
@@ -183,12 +184,14 @@ OpenMetadata Configurations Environment Variables*/}}
   value: "{{ .Values.openmetadata.config.authentication.ldapConfiguration.port }}"
 - name: AUTHENTICATION_LOOKUP_ADMIN_DN
   value: "{{ .Values.openmetadata.config.authentication.ldapConfiguration.dnAdminPrincipal }}"
+{{- if .Values.openmetadata.config.authentication.ldapConfiguration.dnAdminPassword.secretRef -}}
 {{- with .Values.openmetadata.config.authentication.ldapConfiguration.dnAdminPassword }}
 - name: AUTHENTICATION_LOOKUP_ADMIN_PWD
   valueFrom:
     secretKeyRef:
       name: {{ .secretRef }}
       key: {{ .secretKey }}
+{{- end }}
 {{- end }}
 - name: AUTHENTICATION_USER_LOOKUP_BASEDN
   value: "{{ .Values.openmetadata.config.authentication.ldapConfiguration.userBaseDN }}"
@@ -203,12 +206,14 @@ OpenMetadata Configurations Environment Variables*/}}
 {{- if eq .Values.openmetadata.config.authentication.ldapConfiguration.truststoreConfigType "CustomTrustStore" }}
 - name: AUTHENTICATION_LDAP_TRUSTSTORE_PATH
   value: "{{ .Values.openmetadata.config.authentication.ldapConfiguration.trustStoreConfig.customTrustManagerConfig.trustStoreFilePath }}"
+{{- if .Values.openmetadata.config.authentication.ldapConfiguration.trustStoreConfig.customTrustManagerConfig.trustStoreFilePassword.secretRef }}
 {{- with .Values.openmetadata.config.authentication.ldapConfiguration.trustStoreConfig.customTrustManagerConfig.trustStoreFilePassword }}
 - name: AUTHENTICATION_LDAP_KEYSTORE_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ .secretRef }}
       key: {{ .secretKey }}
+{{- end }}
 {{- end }}
 - name: AUTHENTICATION_LDAP_SSL_KEY_FORMAT
   value: "{{ .Values.openmetadata.config.authentication.ldapConfiguration.trustStoreConfig.customTrustManagerConfig.trustStoreFileFormat }}"
@@ -223,11 +228,11 @@ OpenMetadata Configurations Environment Variables*/}}
 - name: AUTHENTICATION_LDAP_ALLOWED_HOSTNAMES
   value: "{{ .Values.openmetadata.config.authentication.ldapConfiguration.trustStoreConfig.hostNameConfig.acceptableHostNames }}"
 {{- end }}
-{{- if eq .Values.openmetadata.config.authentication.ldapConfiguration.truststoreConfigType "JVMDefault" }}          
+{{- if eq .Values.openmetadata.config.authentication.ldapConfiguration.truststoreConfigType "JVMDefault" }}
 - name: AUTHENTICATION_LDAP_SSL_VERIFY_CERT_HOST
   value: "{{ .Values.openmetadata.config.authentication.ldapConfiguration.trustStoreConfig.jvmDefaultConfig.verifyHostname }}"
 {{- end }}
-{{- if eq .Values.openmetadata.config.authentication.ldapConfiguration.truststoreConfigType "TrustAll" }}  
+{{- if eq .Values.openmetadata.config.authentication.ldapConfiguration.truststoreConfigType "TrustAll" }}
 - name: AUTHENTICATION_LDAP_EXAMINE_VALIDITY_DATES
   value: "{{ .Values.openmetadata.config.authentication.ldapConfiguration.trustStoreConfig.trustAllConfig.examineValidityDates }}"
 {{- end }}
@@ -239,12 +244,14 @@ OpenMetadata Configurations Environment Variables*/}}
   value: "{{ .Values.openmetadata.config.authentication.saml.idp.entityId }}"
 - name: SAML_IDP_SSO_LOGIN_URL          
   value: "{{ .Values.openmetadata.config.authentication.saml.idp.ssoLoginUrl }}"
+{{- if .Values.openmetadata.config.authentication.saml.idp.idpX509Certificate.secretRef }}
 {{- with .Values.openmetadata.config.authentication.saml.idp.idpX509Certificate }}
 - name: SAML_IDP_CERTIFICATE
   valueFrom:
     secretKeyRef:
       name: {{ .secretRef }}
       key: {{ .secretKey }}
+{{- end }}
 {{- end }}
 - name: SAML_AUTHORITY_URL
   value: "{{ .Values.openmetadata.config.authentication.saml.idp.authorityUrl }}"
@@ -254,13 +261,15 @@ OpenMetadata Configurations Environment Variables*/}}
   value: "{{ .Values.openmetadata.config.authentication.saml.sp.entityId }}"
 - name: SAML_SP_ACS
   value: "{{ .Values.openmetadata.config.authentication.saml.sp.acs }}"
+{{- if .Values.openmetadata.config.authentication.saml.sp.spX509Certificate.secretRef }}
 {{- with .Values.openmetadata.config.authentication.saml.sp.spX509Certificate }}
 - name: SAML_SP_CERTIFICATE
   valueFrom:
     secretKeyRef:
       name: {{ .secretRef }}
       key: {{ .secretKey }}
-{{- end }}            
+{{- end }}
+{{- end }}
 - name: SAML_SP_CALLBACK
   value: "{{ .Values.openmetadata.config.authentication.saml.sp.callback }}"
 - name: SAML_STRICT_MODE
@@ -285,6 +294,7 @@ OpenMetadata Configurations Environment Variables*/}}
 # Key Store should only be considered if either wantAssertionEncrypted or wantNameIdEncrypted will be true
 - name: SAML_KEYSTORE_FILE_PATH
   value: "{{ .Values.openmetadata.config.authentication.saml.security.keyStoreFilePath }}"
+{{- if .Values.openmetadata.config.authentication.saml.security.keyStoreAlias.secretRef }}
 {{- with .Values.openmetadata.config.authentication.saml.security.keyStoreAlias }}
 - name: SAML_KEYSTORE_ALIAS
   valueFrom:
@@ -292,12 +302,15 @@ OpenMetadata Configurations Environment Variables*/}}
       name: {{ .secretRef }}
       key: {{ .secretKey }}
 {{- end }}
+{{- end }}
+{{- if .Values.openmetadata.config.authentication.saml.security.keyStorePassword.secretRef }}
 {{- with .Values.openmetadata.config.authentication.saml.security.keyStorePassword }}
 - name: SAML_KEYSTORE_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ .secretRef }}
       key: {{ .secretKey }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -317,6 +330,7 @@ OpenMetadata Configurations Environment Variables*/}}
 {{- with .Values.openmetadata.config.elasticsearch.auth }}
 - name: ELASTICSEARCH_USER
   value: "{{ .username }}"
+{{- if .password.secretRef -}}
 - name: ELASTICSEARCH_PASSWORD
   valueFrom:
     secretKeyRef:
@@ -324,9 +338,11 @@ OpenMetadata Configurations Environment Variables*/}}
       key: {{ .password.secretKey }}
 {{- end }}
 {{- end }}
+{{- end }}
 {{- if .Values.openmetadata.config.elasticsearch.trustStore.enabled }}
 - name: ELASTICSEARCH_TRUST_STORE_PATH
   value: {{.Values.openmetadata.config.elasticsearch.trustStore.path }}
+{{- if .Values.openmetadata.config.elasticsearch.trustStore.password.secretRef }}
 {{- with .Values.openmetadata.config.elasticsearch.trustStore }}
 - name: ELASTICSEARCH_TRUST_STORE_PASSWORD
   valueFrom:
@@ -335,18 +351,21 @@ OpenMetadata Configurations Environment Variables*/}}
       key: {{ .password.secretKey }}
 {{- end }}
 {{- end }}
+{{- end }}
 - name: DB_HOST
-  value: "{{ .Values.openmetadata.config.database.host }}"
+  value: "{{ tpl .Values.openmetadata.config.database.host . }}"
 - name: DB_PORT
   value: "{{ .Values.openmetadata.config.database.port }}"
 {{- with .Values.openmetadata.config.database.auth }}
 - name: DB_USER
   value: "{{ .username }}"
+{{- if .password.secretRef -}}
 - name: DB_USER_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ .password.secretRef }}
       key: {{ .password.secretKey }}
+{{- end }}
 {{- end }}
 - name: OM_DATABASE
   value: "{{ .Values.openmetadata.config.database.databaseName }}"
@@ -364,32 +383,35 @@ OpenMetadata Configurations Environment Variables*/}}
 - name: PIPELINE_SERVICE_IP_INFO_ENABLED
   value: "{{ .Values.openmetadata.config.pipelineServiceClientConfig.ingestionIpInfoEnabled }}"
 - name: PIPELINE_SERVICE_CLIENT_ENDPOINT
-  value: "{{ .Values.openmetadata.config.pipelineServiceClientConfig.apiEndpoint }}"
+  value: "{{ tpl .Values.openmetadata.config.pipelineServiceClientConfig.apiEndpoint . }}"
 {{- with .Values.openmetadata.config.pipelineServiceClientConfig.auth }}
 - name: AIRFLOW_USERNAME
   value: "{{ .username }}"
+{{- if .password.secretRef -}}
 - name: AIRFLOW_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ .password.secretRef }}
       key: {{ .password.secretKey }}
 {{- end }}
+{{- end }}
 - name: PIPELINE_SERVICE_CLIENT_VERIFY_SSL
   value: "{{ .Values.openmetadata.config.pipelineServiceClientConfig.verifySsl }}"
 - name: PIPELINE_SERVICE_CLIENT_HOST_IP
   value: "{{ .Values.openmetadata.config.pipelineServiceClientConfig.hostIp }}"
 - name: PIPELINE_SERVICE_CLIENT_HEALTH_CHECK_INTERVAL
-  value: "{{ .Values.openmetadata.config.pipelineServiceClientConfig.healthCheckInterval }}"      
+  value: "{{ .Values.openmetadata.config.pipelineServiceClientConfig.healthCheckInterval }}"
 - name: PIPELINE_SERVICE_CLIENT_SSL_CERT_PATH
   value: "{{ .Values.openmetadata.config.pipelineServiceClientConfig.sslCertificatePath }}"
 - name: SERVER_HOST_API_URL
-  value: "{{ .Values.openmetadata.config.pipelineServiceClientConfig.metadataApiEndpoint }}"
+  value: "{{ tpl .Values.openmetadata.config.pipelineServiceClientConfig.metadataApiEndpoint . }}"
 {{- end }}
 - name: SECRET_MANAGER
   value: "{{ .Values.openmetadata.config.secretsManager.provider }}"
 {{- if .Values.openmetadata.config.secretsManager.additionalParameters.enabled }}
 - name: OM_SM_REGION
   value: "{{ .Values.openmetadata.config.secretsManager.additionalParameters.region }}"
+{{- if .Values.openmetadata.config.secretsManager.additionalParameters.accessKeyId.secretRef -}}
 {{- with .Values.openmetadata.config.secretsManager.additionalParameters.accessKeyId }}
 - name: OM_SM_ACCESS_KEY_ID
   valueFrom:
@@ -397,12 +419,15 @@ OpenMetadata Configurations Environment Variables*/}}
       name: {{ .secretRef }}
       key: {{ .secretKey }}
 {{- end }}
+{{- end }}
+{{- if .Values.openmetadata.config.secretsManager.additionalParameters.secretAccessKey.secretRef -}}
 {{- with .Values.openmetadata.config.secretsManager.additionalParameters.secretAccessKey }}
 - name: OM_SM_ACCESS_KEY
   valueFrom:
     secretKeyRef:
       name: {{ .secretRef }}
       key: {{ .secretKey }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if .Values.openmetadata.config.smtpConfig.enableSmtpServer }}
@@ -420,12 +445,14 @@ OpenMetadata Configurations Environment Variables*/}}
   value: "{{ .Values.openmetadata.config.smtpConfig.serverPort }}"
 - name: SMTP_SERVER_USERNAME
   value: "{{ .Values.openmetadata.config.smtpConfig.username }}"
+{{- if .Values.openmetadata.config.smtpConfig.password.secretRef }}
 {{- with .Values.openmetadata.config.smtpConfig.password }}
 - name: SMTP_SERVER_PWD
   valueFrom:
     secretKeyRef:
       name: {{ .secretRef }}
       key: {{ .secretKey }}
+{{- end }}
 {{- end }}
 - name: SMTP_SERVER_STRATEGY
   value: "{{ .Values.openmetadata.config.smtpConfig.transportationStrategy }}"
@@ -470,5 +497,4 @@ OpenMetadata Configurations Environment Variables*/}}
   value: "{{ .Values.openmetadata.config.web.permissionPolicy.enabled }}"
 - name: WEB_CONF_PERMISSION_POLICY_OPTION
   value: "{{ .Values.openmetadata.config.web.permissionPolicy.option }}"
-
 {{- end }}

--- a/charts/openmetadata/templates/_helpers.tpl
+++ b/charts/openmetadata/templates/_helpers.tpl
@@ -330,7 +330,7 @@ OpenMetadata Configurations Environment Variables*/}}
 {{- with .Values.openmetadata.config.elasticsearch.auth }}
 - name: ELASTICSEARCH_USER
   value: "{{ .username }}"
-{{- if .password.secretRef -}}
+{{- if .password.secretRef }}
 - name: ELASTICSEARCH_PASSWORD
   valueFrom:
     secretKeyRef:
@@ -359,7 +359,7 @@ OpenMetadata Configurations Environment Variables*/}}
 {{- with .Values.openmetadata.config.database.auth }}
 - name: DB_USER
   value: "{{ .username }}"
-{{- if .password.secretRef -}}
+{{- if .password.secretRef }}
 - name: DB_USER_PASSWORD
   valueFrom:
     secretKeyRef:
@@ -387,7 +387,7 @@ OpenMetadata Configurations Environment Variables*/}}
 {{- with .Values.openmetadata.config.pipelineServiceClientConfig.auth }}
 - name: AIRFLOW_USERNAME
   value: "{{ .username }}"
-{{- if .password.secretRef -}}
+{{- if .password.secretRef }}
 - name: AIRFLOW_PASSWORD
   valueFrom:
     secretKeyRef:

--- a/charts/openmetadata/templates/_helpers.tpl
+++ b/charts/openmetadata/templates/_helpers.tpl
@@ -97,7 +97,7 @@ Warning to update openmetadata global keyword to openmetadata.config */}}
 {{/*
 OpenMetadata Configurations Environment Variables*/}}
 {{- define "OpenMetadata.configs" -}}
-{{- if .Values.openmetadata.config.fernetkey.secretRef -}}
+{{- if .Values.openmetadata.config.fernetkey.secretRef }}
 {{- with .Values.openmetadata.config.fernetkey -}}
 - name: FERNET_KEY
   valueFrom:
@@ -184,7 +184,7 @@ OpenMetadata Configurations Environment Variables*/}}
   value: "{{ .Values.openmetadata.config.authentication.ldapConfiguration.port }}"
 - name: AUTHENTICATION_LOOKUP_ADMIN_DN
   value: "{{ .Values.openmetadata.config.authentication.ldapConfiguration.dnAdminPrincipal }}"
-{{- if .Values.openmetadata.config.authentication.ldapConfiguration.dnAdminPassword.secretRef -}}
+{{- if .Values.openmetadata.config.authentication.ldapConfiguration.dnAdminPassword.secretRef }}
 {{- with .Values.openmetadata.config.authentication.ldapConfiguration.dnAdminPassword }}
 - name: AUTHENTICATION_LOOKUP_ADMIN_PWD
   valueFrom:
@@ -411,7 +411,7 @@ OpenMetadata Configurations Environment Variables*/}}
 {{- if .Values.openmetadata.config.secretsManager.additionalParameters.enabled }}
 - name: OM_SM_REGION
   value: "{{ .Values.openmetadata.config.secretsManager.additionalParameters.region }}"
-{{- if .Values.openmetadata.config.secretsManager.additionalParameters.accessKeyId.secretRef -}}
+{{- if .Values.openmetadata.config.secretsManager.additionalParameters.accessKeyId.secretRef }}
 {{- with .Values.openmetadata.config.secretsManager.additionalParameters.accessKeyId }}
 - name: OM_SM_ACCESS_KEY_ID
   valueFrom:
@@ -420,7 +420,7 @@ OpenMetadata Configurations Environment Variables*/}}
       key: {{ .secretKey }}
 {{- end }}
 {{- end }}
-{{- if .Values.openmetadata.config.secretsManager.additionalParameters.secretAccessKey.secretRef -}}
+{{- if .Values.openmetadata.config.secretsManager.additionalParameters.secretAccessKey.secretRef }}
 {{- with .Values.openmetadata.config.secretsManager.additionalParameters.secretAccessKey }}
 - name: OM_SM_ACCESS_KEY
   valueFrom:


### PR DESCRIPTION
### Describe your changes :

I worked on unifying the way secret values are pulled to OM deployment. Currently this chart works under assumption that every secret value (cert, password, etc.) is pulled from k8s secrets but that doesn't have to be the case. In some deployments (such as ours) values are populated using external secrets provider (like hashicorp vault) using init containers. Since we don't want to reference k8s secrets this refactor provides unified approach towards disabling referencing secrets - if secretRef is empty then env variable won't be included in the deployment.

I also made couple of variables to leverage tpl (like cluster name) as users might want to inject namespace or release details into them.

#
### Type of change :

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [x] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers

@shahsank3t @ayush-shah 