### PR TITLE
feat: Prepare 1.2.0 Release

### DIFF
--- a/charts/deps/Chart.lock
+++ b/charts/deps/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 9.7.1
 - name: elasticsearch
   repository: https://helm.elastic.co
-  version: 7.16.3
+  version: 8.5.1
 - name: airflow
   repository: https://airflow-helm.github.io/charts
   version: 8.8.0
-digest: sha256:dfbdae7c1d15a3341434ae4b288c5df316e9caf578743aaabb8a5dc5b3d40f2b
-generated: "2023-09-15T20:28:01.84969+05:30"
+digest: sha256:c4a68ed6f7480bda021d99bb39daf90ed686edeae3605389158b2fc5b9d05f7c
+generated: "2023-10-26T15:20:32.348887+05:30"

--- a/charts/deps/Chart.yaml
+++ b/charts/deps/Chart.yaml
@@ -64,7 +64,7 @@ dependencies:
   repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
   condition: mysql.enabled
 - name: elasticsearch
-  version: "7.16.3"
+  version: "8.5.1"
   repository: "https://helm.elastic.co"
   condition: elasticsearch.enabled
 - name: airflow

--- a/charts/deps/Chart.yaml
+++ b/charts/deps/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.1.14
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.1.7"
+appVersion: "1.2.0"
 
 home: https://open-metadata.org/
 

--- a/charts/deps/values.yaml
+++ b/charts/deps/values.yaml
@@ -56,7 +56,7 @@ airflow:
   airflow:
     image:
       repository: docker.getcollate.io/openmetadata/ingestion
-      tag: 1.1.7
+      tag: 1.2.0
       pullPolicy: "IfNotPresent"
     executor: "KubernetesExecutor"
     config:

--- a/charts/openmetadata/Chart.yaml
+++ b/charts/openmetadata/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.1.14
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.1.7"
+appVersion: "1.2.0"
 
 home: https://open-metadata.org/
 

--- a/charts/openmetadata/README.md
+++ b/charts/openmetadata/README.md
@@ -108,8 +108,8 @@ helm install openmetadata open-metadata/openmetadata --values <<path-to-values-f
 | openmetadata.config.database.auth.password.secretKey | string | `openmetadata-mysql-password` | DB_USER_PASSWORD |
 | openmetadata.config.database.auth.username | string | `openmetadata_user` | DB_USER|
 | openmetadata.config.database.databaseName | string | `openmetadata_db` | OM_DATABASE |
+| openmetadata.config.database.dbParams| string | `allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=UTC` | DB_PARAMS |
 | openmetadata.config.database.dbScheme| string | `mysql` | DB_SCHEME |
-| openmetadata.config.database.dbUseSSL| bool | `false` | DB_USE_SSL |
 | openmetadata.config.database.driverClass| string | `com.mysql.cj.jdbc.Driver` | DB_DRIVER_CLASS |
 | openmetadata.config.database.host | string | `mysql` | DB_HOST |
 | openmetadata.config.database.port | int | 3306 | DB_PORT |
@@ -141,6 +141,7 @@ helm install openmetadata open-metadata/openmetadata --values <<path-to-values-f
 | openmetadata.config.jwtTokenConfiguration.keyId | string | `Gb389a-9f76-gdjs-a92j-0242bk94356` | JWT_KEY_ID |
 | openmetadata.config.logLevel | string | `INFO` | LOG_LEVEL |
 | openmetadata.config.maskPasswordsApi | bool | `false` | MASK_PASSWORDS_API |
+| openmetadata.config.migrationConfigs.extensionPath | string | `Empty string` | MIGRATION_EXTENSION_PATH |
 | openmetadata.config.openmetadata.adminPort | int | 8586 | SERVER_ADMIN_PORT |
 | openmetadata.config.openmetadata.host | string | `openmetadata` | OPENMETADATA_SERVER_URL |
 | openmetadata.config.openmetadata.port | int | 8585 | SERVER_PORT |
@@ -149,7 +150,7 @@ helm install openmetadata open-metadata/openmetadata --values <<path-to-values-f
 | openmetadata.config.pipelineServiceClientConfig.auth.username | string | `admin` | AIRFLOW_USERNAME |
 | openmetadata.config.pipelineServiceClientConfig.apiEndpoint | string | `http://openmetadata-dependencies-web:8080` | PIPELINE_SERVICE_CLIENT_ENDPOINT |
 | openmetadata.config.pipelineServiceClientConfig.className | string | `org.openmetadata.service.clients.pipeline.airflow.AirflowRESTClient` | PIPELINE_SERVICE_CLIENT_CLASS_NAME |
-| openmetadata.config.pipelineServiceClientConfig.enabled | bool | `true` | |
+| openmetadata.config.pipelineServiceClientConfig.enabled | bool | `true` | PIPELINE_SERVICE_CLIENT_ENABLED |
 | openmetadata.config.pipelineServiceClientConfig.healthCheckInterval | int | `300` | PIPELINE_SERVICE_CLIENT_HEALTH_CHECK_INTERVAL |
 | openmetadata.config.pipelineServiceClientConfig.ingestionIpInfoEnabled | bool | `false` | PIPELINE_SERVICE_IP_INFO_ENABLED |
 | openmetadata.config.pipelineServiceClientConfig.metadataApiEndpoint | string | `http://openmetadata:8585/api` | SERVER_HOST_API_URL |

--- a/charts/openmetadata/README.md
+++ b/charts/openmetadata/README.md
@@ -209,7 +209,7 @@ helm install openmetadata open-metadata/openmetadata --values <<path-to-values-f
 | fullnameOverride | string | `"openmetadata"` |
 | image.pullPolicy | string | `"Always"` |
 | image.repository | string | `"docker.getcollate.io/openmetadata/server"` |
-| image.tag | string | `1.1.7` |
+| image.tag | string | `1.2.0` |
 | imagePullSecrets | list | `[]` |
 | ingress.annotations | object | `{}` |
 | ingress.className | string | `""` |

--- a/charts/openmetadata/templates/_helpers.tpl
+++ b/charts/openmetadata/templates/_helpers.tpl
@@ -110,6 +110,8 @@ OpenMetadata Configurations Environment Variables*/}}
       name: {{ include "OpenMetadata.fullname" . }}-secret 
       key: FERNET_KEY
 {{- end }}
+- name: MIGRATION_EXTENSION_PATH
+  value: "{{ .Values.openmetadata.config.migrationConfigs.extensionPath }}"
 - name: EVENT_MONITOR
   value: "{{ .Values.openmetadata.config.eventMonitor.type }}"
 - name: EVENT_MONITOR_BATCH_SIZE
@@ -352,9 +354,11 @@ OpenMetadata Configurations Environment Variables*/}}
   value: "{{ .Values.openmetadata.config.database.driverClass }}"
 - name: DB_SCHEME
   value: "{{ .Values.openmetadata.config.database.dbScheme }}"
-- name: DB_USE_SSL
-  value: "{{ .Values.openmetadata.config.database.dbUseSSL }}"
+- name: DB_PARAMS
+  value: "{{ .Values.openmetadata.config.database.dbParams }}"
 {{- if .Values.openmetadata.config.pipelineServiceClientConfig.enabled }}
+- name: PIPELINE_SERVICE_CLIENT_ENABLED
+  value: "{{ .Values.openmetadata.config.pipelineServiceClientConfig.enabled }}"
 - name: PIPELINE_SERVICE_CLIENT_CLASS_NAME
   value: "{{ .Values.openmetadata.config.pipelineServiceClientConfig.className }}"
 - name: PIPELINE_SERVICE_IP_INFO_ENABLED

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -873,15 +873,11 @@
         },
         "image": {
             "type": "object",
-            "additionalProperties": false,
             "properties": {
                 "pullPolicy": {
                     "type": "string"
                 },
                 "repository": {
-                    "type": "string"
-                },
-                "tag": {
                     "type": "string"
                 }
             }

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -39,6 +39,15 @@
                         "errorMessage": "Global keyword has been replaced by openmetadata.config"
                     },
                     "properties": {
+                        "migrationConfigs": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "extensionPath": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "web": {
                             "type": "object",
                             "additionalProperties": false,
@@ -586,8 +595,8 @@
                                 "dbScheme": {
                                     "type": "string"
                                 },
-                                "dbUseSSL": {
-                                    "type": "boolean"
+                                "dbParams": {
+                                    "type": "string"
                                 },
                                 "driverClass": {
                                     "type": "string"

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -7,6 +7,8 @@ replicaCount: 1
 # Below are defaults as per openmetadata-dependencies Helm Chart Values
 openmetadata:
   config:
+    migrationConfigs:
+      extensionPath: ""
     upgradeMigrationConfigs:
       force: false
       migrationLimitParam: 1200
@@ -47,13 +49,13 @@ openmetadata:
       port: 3306
       driverClass: com.mysql.cj.jdbc.Driver
       dbScheme: mysql
-      dbUseSSL: false
       databaseName: openmetadata_db
       auth:
         username: openmetadata_user
         password:
           secretRef: mysql-secrets
           secretKey: openmetadata-mysql-password
+      dbParams: "allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=UTC"
     pipelineServiceClientConfig:
       enabled: true
       className: "org.openmetadata.service.clients.pipeline.airflow.AirflowRESTClient"


### PR DESCRIPTION
Breaking Changes -

- Removal of helm values `openmetadata.config.database.dbUseSSL`. This is deprecated and removed in favour of `openmetadata.config.database.dbParams`
- Update ElasticSearch Helm Chart Dependencies to `8.5.1`

Additions -
- `openmetadata.config.database.dbParams` to add addition Database Parameters as string format
- `openmetadata.config.migrationConfigs.extensionPath` for migration extensionPath

Fixes -
- Add Environment Variable for `openmetadata.config.pipelineServiceClientConfig.enabled` usage
- Fix schema constraints on OpenMetadata Repository Tags and Image names

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)