### PR TITLE
Update templates to use database env from secret

### DIFF
--- a/charts/openmetadata/templates/_helpers.tpl
+++ b/charts/openmetadata/templates/_helpers.tpl
@@ -335,27 +335,13 @@ OpenMetadata Configurations Environment Variables*/}}
       key: {{ .password.secretKey }}
 {{- end }}
 {{- end }}
-- name: DB_HOST
-  value: "{{ .Values.openmetadata.config.database.host }}"
-- name: DB_PORT
-  value: "{{ .Values.openmetadata.config.database.port }}"
 {{- with .Values.openmetadata.config.database.auth }}
-- name: DB_USER
-  value: "{{ .username }}"
 - name: DB_USER_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ .password.secretRef }}
       key: {{ .password.secretKey }}
 {{- end }}
-- name: OM_DATABASE
-  value: "{{ .Values.openmetadata.config.database.databaseName }}"
-- name: DB_DRIVER_CLASS
-  value: "{{ .Values.openmetadata.config.database.driverClass }}"
-- name: DB_SCHEME
-  value: "{{ .Values.openmetadata.config.database.dbScheme }}"
-- name: DB_PARAMS
-  value: "{{ .Values.openmetadata.config.database.dbParams }}"
 {{- if .Values.openmetadata.config.pipelineServiceClientConfig.enabled }}
 - name: PIPELINE_SERVICE_CLIENT_ENABLED
   value: "{{ .Values.openmetadata.config.pipelineServiceClientConfig.enabled }}"

--- a/charts/openmetadata/templates/_helpers.tpl
+++ b/charts/openmetadata/templates/_helpers.tpl
@@ -301,22 +301,8 @@ OpenMetadata Configurations Environment Variables*/}}
 {{- end }}
 {{- end }}
 {{- end }}
-- name: ELASTICSEARCH_HOST
-  value: "{{ .Values.openmetadata.config.elasticsearch.host }}"
-- name: SEARCH_TYPE
-  value: "{{ .Values.openmetadata.config.elasticsearch.searchType }}"
-- name: ELASTICSEARCH_PORT
-  value: "{{ .Values.openmetadata.config.elasticsearch.port }}"
-- name: ELASTICSEARCH_SCHEME
-  value: "{{ .Values.openmetadata.config.elasticsearch.scheme }}"
-- name: ELASTICSEARCH_INDEX_MAPPING_LANG
-  value: "{{ .Values.openmetadata.config.elasticsearch.searchIndexMappingLanguage }}"
-- name: ELASTICSEARCH_KEEP_ALIVE_TIMEOUT_SECS
-  value: "{{ .Values.openmetadata.config.elasticsearch.keepAliveTimeoutSecs }}"
 {{- if .Values.openmetadata.config.elasticsearch.auth.enabled -}}
 {{- with .Values.openmetadata.config.elasticsearch.auth }}
-- name: ELASTICSEARCH_USER
-  value: "{{ .username }}"
 - name: ELASTICSEARCH_PASSWORD
   valueFrom:
     secretKeyRef:
@@ -325,8 +311,6 @@ OpenMetadata Configurations Environment Variables*/}}
 {{- end }}
 {{- end }}
 {{- if .Values.openmetadata.config.elasticsearch.trustStore.enabled }}
-- name: ELASTICSEARCH_TRUST_STORE_PATH
-  value: {{.Values.openmetadata.config.elasticsearch.trustStore.path }}
 {{- with .Values.openmetadata.config.elasticsearch.trustStore }}
 - name: ELASTICSEARCH_TRUST_STORE_PASSWORD
   valueFrom:

--- a/charts/openmetadata/templates/deployment.yaml
+++ b/charts/openmetadata/templates/deployment.yaml
@@ -36,10 +36,12 @@ spec:
           {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
-        {{- with .Values.envFrom }}
         envFrom:
-            {{- toYaml . | nindent 10 }}
-          {{- end }}
+        - secretRef:
+            name: {{ include "OpenMetadata.fullname" . }}-db-secret
+        {{- with .Values.envFrom }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         - name: MIGRATION_LIMIT_PARAM
           value: "{{ .Values.openmetadata.config.upgradeMigrationConfigs.migrationLimitParam }}"
@@ -80,8 +82,10 @@ spec:
           {{- with .Values.extraEnvs }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- with .Values.envFrom }}
           envFrom:
+          - secretRef:
+              name: {{ include "OpenMetadata.fullname" . }}-db-secret
+          {{- with .Values.envFrom }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
           resources:

--- a/charts/openmetadata/templates/deployment.yaml
+++ b/charts/openmetadata/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
         envFrom:
         - secretRef:
             name: {{ include "OpenMetadata.fullname" . }}-db-secret
+        - secretRef:
+            name: {{ include "OpenMetadata.fullname" . }}-search-secret
         {{- with .Values.envFrom }}
           {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -85,6 +87,8 @@ spec:
           envFrom:
           - secretRef:
               name: {{ include "OpenMetadata.fullname" . }}-db-secret
+          - secretRef:
+            name: {{ include "OpenMetadata.fullname" . }}-search-secret
           {{- with .Values.envFrom }}
             {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/charts/openmetadata/templates/secrets.yaml
+++ b/charts/openmetadata/templates/secrets.yaml
@@ -4,8 +4,17 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "OpenMetadata.fullname" . }}-secret
+  name: {{ include "OpenMetadata.fullname" . }}-db-secret
 type: Opaque
 data:
-  FERNET_KEY: {{ .Values.openmetadata.config.fernetkey.value | b64enc | quote }}
+{{- with .Values.openmetadata.config }}
+  FERNET_KEY: {{ .fernetkey.value | b64enc | quote }}
+  DB_HOST: {{ .database.host | b64enc }}
+  DB_PORT: {{ .database.port | quote | b64enc }}
+  DB_DRIVER_CLASS: {{ .database.driverClass | b64enc }}
+  DB_SCHEME: {{ .database.dbScheme | b64enc }}
+  OM_DATABASE: {{ .database.databaseName | b64enc }}
+  DB_PARAMS: {{ .database.dbParams | b64enc | quote }}
+  DB_USER: {{ .database.auth.username | b64enc }}
+{{ end }}
 {{ end }}

--- a/charts/openmetadata/templates/secrets.yaml
+++ b/charts/openmetadata/templates/secrets.yaml
@@ -18,3 +18,25 @@ data:
   DB_USER: {{ .database.auth.username | b64enc }}
 {{ end }}
 {{ end }}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "OpenMetadata.fullname" . }}-search-secret
+type: Opaque
+data:
+{{- with .Values.openmetadata.config.elasticsearch }}
+  ELASTICSEARCH_HOST: {{ .host | b64enc }}
+  SEARCH_TYPE: {{ .searchType | b64enc }}
+  ELASTICSEARCH_PORT: {{ .port | quote | b64enc }}
+  ELASTICSEARCH_SCHEME: {{ .scheme | b64enc }}
+  ELASTICSEARCH_INDEX_MAPPING_LANG: {{ .searchIndexMappingLanguage | b64enc }}
+  ELASTICSEARCH_KEEP_ALIVE_TIMEOUT_SECS: {{ .keepAliveTimeoutSecs | quote | b64enc }}
+  {{- if .trustStore.enabled }}
+  ELASTICSEARCH_TRUST_STORE_PATH: {{ .trustStore.path | b64enc }}
+  {{ end }}
+  {{- if .auth.enabled }}
+  ELASTICSEARCH_USER: {{ .auth.username | b64enc }}
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
### Describe your changes :
I worked on updating the secret for openmetadata server. Currently database configs are injected through _helpers.tpl template to the containers via env instruction in deployment. With this change, the database configs will be stored in secret and will be passed though envFrom instruction to the containers.

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@akash-jain-10 