### PR TITLE
Fix null value secrets

### DIFF
--- a/charts/openmetadata/templates/_helpers.tpl
+++ b/charts/openmetadata/templates/_helpers.tpl
@@ -97,15 +97,6 @@ Warning to update openmetadata global keyword to openmetadata.config */}}
 {{- end }}
 
 {{/*
-Function for setting PIPELINE_SERVICE_CLIENT_HOST_IP in pipeline-secret */}}
-{{- define "OpenMetadata.utils.setHostIP" -}}
-{{- $value := include "OpenMetadata.utils.checkEmptyString" . }}
-{{- if eq $value "true" }}
-PIPELINE_SERVICE_CLIENT_HOST_IP: {{ . | quote | b64enc }}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Function to check if passed value is empty string or null value */}}
 {{- define "OpenMetadata.utils.checkEmptyString" -}}
 {{- if or (empty .) (eq . "") -}}

--- a/charts/openmetadata/templates/_helpers.tpl
+++ b/charts/openmetadata/templates/_helpers.tpl
@@ -97,6 +97,25 @@ Warning to update openmetadata global keyword to openmetadata.config */}}
 {{- end }}
 
 {{/*
+Function for setting PIPELINE_SERVICE_CLIENT_HOST_IP in pipeline-secret */}}
+{{- define "OpenMetadata.utils.setHostIP" -}}
+{{- $value := include "OpenMetadata.utils.checkEmptyString" . }}
+{{- if eq $value "true" }}
+PIPELINE_SERVICE_CLIENT_HOST_IP: {{ . | quote | b64enc }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Function to check if passed value is empty string or null value */}}
+{{- define "OpenMetadata.utils.checkEmptyString" -}}
+{{- if or (empty .) (eq . "") -}}
+{{- false -}}
+{{- else -}}
+{{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 OpenMetadata Configurations Environment Variables*/}}
 {{- define "OpenMetadata.configs" -}}
 {{- if .Values.openmetadata.config.fernetkey.secretRef -}}

--- a/charts/openmetadata/templates/secrets.yaml
+++ b/charts/openmetadata/templates/secrets.yaml
@@ -63,7 +63,7 @@ metadata:
   name: {{ include "OpenMetadata.fullname" . }}-pipeline-secret
 type: Opaque
 data:
-{{ include "OpenMetadata.utils.setHostIP" .Values.openmetadata.config.pipelineServiceClientConfig.hostIp | indent 2 }}
+{{- include "OpenMetadata.utils.setHostIP" .Values.openmetadata.config.pipelineServiceClientConfig.hostIp | indent 2 }}
 {{- with .Values.openmetadata.config.pipelineServiceClientConfig }}
   PIPELINE_SERVICE_CLIENT_ENABLED: {{ .enabled | quote | b64enc }}
   PIPELINE_SERVICE_CLIENT_CLASS_NAME: {{ .className | quote | b64enc }}

--- a/charts/openmetadata/templates/secrets.yaml
+++ b/charts/openmetadata/templates/secrets.yaml
@@ -63,8 +63,8 @@ metadata:
   name: {{ include "OpenMetadata.fullname" . }}-pipeline-secret
 type: Opaque
 data:
-{{- include "OpenMetadata.utils.setHostIP" .Values.openmetadata.config.pipelineServiceClientConfig.hostIp | indent 2 }}
 {{- with .Values.openmetadata.config.pipelineServiceClientConfig }}
+{{- include "OpenMetadata.utils.setHostIP" .hostIp | indent 2 }}
   PIPELINE_SERVICE_CLIENT_ENABLED: {{ .enabled | quote | b64enc }}
   PIPELINE_SERVICE_CLIENT_CLASS_NAME: {{ .className | quote | b64enc }}
   PIPELINE_SERVICE_IP_INFO_ENABLED: {{ .ingestionIpInfoEnabled | quote | b64enc }}

--- a/charts/openmetadata/templates/secrets.yaml
+++ b/charts/openmetadata/templates/secrets.yaml
@@ -63,13 +63,13 @@ metadata:
   name: {{ include "OpenMetadata.fullname" . }}-pipeline-secret
 type: Opaque
 data:
+{{ include "OpenMetadata.utils.setHostIP" .Values.openmetadata.config.pipelineServiceClientConfig.hostIp | indent 2 }}
 {{- with .Values.openmetadata.config.pipelineServiceClientConfig }}
   PIPELINE_SERVICE_CLIENT_ENABLED: {{ .enabled | quote | b64enc }}
   PIPELINE_SERVICE_CLIENT_CLASS_NAME: {{ .className | quote | b64enc }}
   PIPELINE_SERVICE_IP_INFO_ENABLED: {{ .ingestionIpInfoEnabled | quote | b64enc }}
   PIPELINE_SERVICE_CLIENT_ENDPOINT: {{ .apiEndpoint | b64enc }}
   PIPELINE_SERVICE_CLIENT_VERIFY_SSL: {{ .verifySsl | quote | b64enc }}
-  PIPELINE_SERVICE_CLIENT_HOST_IP: {{ .hostIp | b64enc }}
   PIPELINE_SERVICE_CLIENT_HEALTH_CHECK_INTERVAL: {{ .healthCheckInterval | quote | b64enc }}
   PIPELINE_SERVICE_CLIENT_SSL_CERT_PATH: {{ .sslCertificatePath | quote | b64enc }}
   SERVER_HOST_API_URL: {{ .metadataApiEndpoint | b64enc }}

--- a/charts/openmetadata/templates/secrets.yaml
+++ b/charts/openmetadata/templates/secrets.yaml
@@ -64,7 +64,9 @@ metadata:
 type: Opaque
 data:
 {{- with .Values.openmetadata.config.pipelineServiceClientConfig }}
-{{- include "OpenMetadata.utils.setHostIP" .hostIp | indent 2 }}
+{{- if eq (include "OpenMetadata.utils.checkEmptyString" .hostIp) "true" }}
+  PIPELINE_SERVICE_CLIENT_HOST_IP: {{ .hostIp | quote | b64enc }}
+{{- end }}
   PIPELINE_SERVICE_CLIENT_ENABLED: {{ .enabled | quote | b64enc }}
   PIPELINE_SERVICE_CLIENT_CLASS_NAME: {{ .className | quote | b64enc }}
   PIPELINE_SERVICE_IP_INFO_ENABLED: {{ .ingestionIpInfoEnabled | quote | b64enc }}


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
We have been reported with [an issue](https://openmetadata.slack.com/archives/C02B6955S4S/p1702923271280889) with the new helm chart (OMD app version - 1.2.3 and Chart version - 1.2.5)

Apparently, when the "hostIp" value is kept empty (or "") in the values.yaml file, the secrets template creates a null value secret for it which results in error while upgrading/installing the newer version of the helm chart.

With these changes, secret for hostIP won't be created unless it is non-empty.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests passed.

#
### Reviewers
@akash-jain-10 