### PR TITLE
feat: Prepare for 1.2.4 Release

### DIFF
--- a/charts/openmetadata/Chart.yaml
+++ b/charts/openmetadata/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.2.5
+version: 1.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.3"
+appVersion: "1.2.4"
 
 home: https://open-metadata.org/
 

--- a/charts/openmetadata/README.md
+++ b/charts/openmetadata/README.md
@@ -149,6 +149,9 @@ helm install openmetadata open-metadata/openmetadata --values <<path-to-values-f
 | openmetadata.config.pipelineServiceClientConfig.auth.password.secretRef | string | `airflow-secrets` | AIRFLOW_PASSWORD |
 | openmetadata.config.pipelineServiceClientConfig.auth.password.secretKey | string | `openmetadata-airflow-password` | AIRFLOW_PASSWORD |
 | openmetadata.config.pipelineServiceClientConfig.auth.username | string | `admin` | AIRFLOW_USERNAME |
+| openmetadata.config.pipelineServiceClientConfig.auth.trustStorePath | string | `` | AIRFLOW_TRUST_STORE_PATH |
+| openmetadata.config.pipelineServiceClientConfig.auth.trustStorePassword.secretRef | string | `` | AIRFLOW_TRUST_STORE_PASSWORD |
+| openmetadata.config.pipelineServiceClientConfig.auth.trustStorePassword.secretKey | string | `` | AIRFLOW_TRUST_STORE_PASSWORD |
 | openmetadata.config.pipelineServiceClientConfig.apiEndpoint | string | `http://openmetadata-dependencies-web:8080` | PIPELINE_SERVICE_CLIENT_ENDPOINT |
 | openmetadata.config.pipelineServiceClientConfig.className | string | `org.openmetadata.service.clients.pipeline.airflow.AirflowRESTClient` | PIPELINE_SERVICE_CLIENT_CLASS_NAME |
 | openmetadata.config.pipelineServiceClientConfig.enabled | bool | `true` | PIPELINE_SERVICE_CLIENT_ENABLED |

--- a/charts/openmetadata/templates/_helpers.tpl
+++ b/charts/openmetadata/templates/_helpers.tpl
@@ -206,6 +206,15 @@ OpenMetadata Configurations Environment Variables*/}}
       key: {{ .secretKey }}
 {{- end }}
 {{- end }}
+{{- if .Values.openmetadata.config.pipelineServiceClientConfig.auth.truststorePassword.secretRef }}
+{{- with .Values.openmetadata.config.pipelineServiceClientConfig.auth.truststorePassword }}
+- name: AIRFLOW_TRUST_STORE_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .secretRef }}
+      key: {{ .secretKey }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- if .Values.openmetadata.config.secretsManager.additionalParameters.enabled }}
 {{- if .Values.openmetadata.config.secretsManager.additionalParameters.accessKeyId.secretRef }}

--- a/charts/openmetadata/templates/_helpers.tpl
+++ b/charts/openmetadata/templates/_helpers.tpl
@@ -206,8 +206,8 @@ OpenMetadata Configurations Environment Variables*/}}
       key: {{ .secretKey }}
 {{- end }}
 {{- end }}
-{{- if .Values.openmetadata.config.pipelineServiceClientConfig.auth.truststorePassword.secretRef }}
-{{- with .Values.openmetadata.config.pipelineServiceClientConfig.auth.truststorePassword }}
+{{- if .Values.openmetadata.config.pipelineServiceClientConfig.auth.trustStorePassword.secretRef }}
+{{- with .Values.openmetadata.config.pipelineServiceClientConfig.auth.trustStorePassword }}
 - name: AIRFLOW_TRUST_STORE_PASSWORD
   valueFrom:
     secretKeyRef:

--- a/charts/openmetadata/templates/secrets.yaml
+++ b/charts/openmetadata/templates/secrets.yaml
@@ -75,6 +75,7 @@ data:
   SERVER_HOST_API_URL: {{ .metadataApiEndpoint | b64enc }}
   {{- if .auth.enabled }}
   AIRFLOW_USERNAME: {{ .auth.username | b64enc }}
+  AIRFLOW_TRUST_STORE_PATH: {{ .auth.truststorePath | quote | b64enc }}
   {{- end }}
 {{ end }}
 {{ end }}

--- a/charts/openmetadata/templates/secrets.yaml
+++ b/charts/openmetadata/templates/secrets.yaml
@@ -75,7 +75,7 @@ data:
   SERVER_HOST_API_URL: {{ .metadataApiEndpoint | b64enc }}
   {{- if .auth.enabled }}
   AIRFLOW_USERNAME: {{ .auth.username | b64enc }}
-  AIRFLOW_TRUST_STORE_PATH: {{ .auth.truststorePath | quote | b64enc }}
+  AIRFLOW_TRUST_STORE_PATH: {{ .auth.trustStorePath | quote | b64enc }}
   {{- end }}
 {{ end }}
 {{ end }}

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -186,6 +186,21 @@
                                         },
                                         "username": {
                                             "type": "string"
+                                        },
+                                        "truststorePath" : {
+                                            "type": "string"
+                                        },
+                                        "truststorePassword": {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "secretKey": {
+                                                    "type": "string"
+                                                },
+                                                "secretRef": {
+                                                    "type": "string"
+                                                }
+                                            }
                                         }
                                     }
                                 },

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -187,10 +187,10 @@
                                         "username": {
                                             "type": "string"
                                         },
-                                        "truststorePath" : {
+                                        "trustStorePath" : {
                                             "type": "string"
                                         },
-                                        "truststorePassword": {
+                                        "trustStorePassword": {
                                             "type": "object",
                                             "additionalProperties": false,
                                             "properties": {

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -76,8 +76,8 @@ openmetadata:
         password:
           secretRef: airflow-secrets
           secretKey: openmetadata-airflow-password
-        truststorePath: ""
-        truststorePassword:
+        trustStorePath: ""
+        trustStorePassword:
           secretRef: ""
           secretKey: ""
     authorizer:

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -76,6 +76,10 @@ openmetadata:
         password:
           secretRef: airflow-secrets
           secretKey: openmetadata-airflow-password
+        truststorePath: ""
+        truststorePassword:
+          secretRef: ""
+          secretKey: ""
     authorizer:
       enabled: true
       className: "org.openmetadata.service.security.DefaultAuthorizer"


### PR DESCRIPTION
### Describe your changes :

The pipelineServiceClientConfig were missing a couple of parameters i.e. `truststorePath` and `truststorePassword` as per the new server release v1.2.4 ([reference](https://github.com/open-metadata/OpenMetadata/blob/1.2.4/conf/openmetadata.yaml#L272-L273)).
Hence updated the required files to include these parameters in helm charts.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @shahsank3t -->
<!--- @sureshms @harshach -->
<!--- @ayush-shah @akash-jain-10 -->