### PR TITLE
Add service monitor labels

### DIFF
--- a/charts/openmetadata/README.md
+++ b/charts/openmetadata/README.md
@@ -31,7 +31,7 @@ helm install openmetadata open-metadata/openmetadata --values <<path-to-values-f
 
 ## Openmetadata Config Chart Values
 
-| Key | Type | Default | Conf/Openmetadata.yaml | 
+| Key | Type | Default | Conf/Openmetadata.yaml |
 |-----|------|---------| ---------------------- |
 | openmetadata.config.authentication.enabled | bool | `true` | |
 | openmetadata.config.authentication.provider | string | `basic` | AUTHENTICATION_PROVIDER |
@@ -65,7 +65,7 @@ helm install openmetadata open-metadata/openmetadata --values <<path-to-values-f
 | openmetadata.config.authentication.saml.idp.entityId | string | `Empty` | SAML_IDP_ENTITY_ID |
 | openmetadata.config.authentication.saml.idp.ssoLoginUrl |  string | `Empty` | SAML_IDP_SSO_LOGIN_URL |
 | openmetadata.config.authentication.saml.idp.idpX509Certificate.secretRef | string | `Empty` | SAML_IDP_CERTIFICATE |
-| openmetadata.config.authentication.saml.idp.idpX509Certificate.secretKey |  string | `Empty` | SAML_IDP_CERTIFICATE | 
+| openmetadata.config.authentication.saml.idp.idpX509Certificate.secretKey |  string | `Empty` | SAML_IDP_CERTIFICATE |
 | openmetadata.config.authentication.saml.idp.authorityUrl | string | `http://openmetadata:8585/api/v1/saml/login` | SAML_AUTHORITY_URL |
 | openmetadata.config.authentication.saml.idp.nameId | string | `urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress` | SAML_IDP_NAME_ID |
 | openmetadata.config.authentication.saml.sp.entityId | string | `http://openmetadata:8585/api/v1/saml/metadata` | SAML_SP_ENTITY_ID |
@@ -156,7 +156,7 @@ helm install openmetadata open-metadata/openmetadata --values <<path-to-values-f
 | openmetadata.config.pipelineServiceClientConfig.ingestionIpInfoEnabled | bool | `false` | PIPELINE_SERVICE_IP_INFO_ENABLED |
 | openmetadata.config.pipelineServiceClientConfig.metadataApiEndpoint | string | `http://openmetadata:8585/api` | SERVER_HOST_API_URL |
 | openmetadata.config.pipelineServiceClientConfig.sslCertificatePath | string | `/no/path` | PIPELINE_SERVICE_CLIENT_SSL_CERT_PATH |
-| openmetadata.config.pipelineServiceClientConfig.verifySsl | string | `no-ssl` | PIPELINE_SERVICE_CLIENT_VERIFY_SSL | 
+| openmetadata.config.pipelineServiceClientConfig.verifySsl | string | `no-ssl` | PIPELINE_SERVICE_CLIENT_VERIFY_SSL |
 | openmetadata.config.pipelineServiceClientConfig.hostIp | string | `Empty` | PIPELINE_SERVICE_CLIENT_HOST_IP |
 | openmetadata.config.secretsManager.enabled | bool | `true` | |
 | openmetadata.config.secretsManager.provider | string | `noop` | SECRET_MANAGER |
@@ -248,6 +248,7 @@ helm install openmetadata open-metadata/openmetadata --values <<path-to-values-f
 | serviceMonitor.annotations | object | `{}` |
 | serviceMonitor.enabled | bool | `false` |
 | serviceMonitor.interval | string | `30s` |
+| serviceMonitor.labels | object | `{}` |
 | sidecars | list | `[]` |
 | startupProbe.periodSeconds | int | `60` |
 | startupProbe.failureThreshold | int | `5` |

--- a/charts/openmetadata/templates/servicemonitor.yaml
+++ b/charts/openmetadata/templates/servicemonitor.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "OpenMetadata.fullname" . }}
   labels:
     {{- include "OpenMetadata.labels" . | indent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.serviceMonitor.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -322,6 +322,7 @@ serviceMonitor:
   enabled: false
   interval: 30s
   annotations: {}
+  labels: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
### Describe your changes :
There is no way to specify labels that only go to the service monitor.  This PR adds the ability to add labels just to the service monitor.

#
### Type of change :
- [x] Improvement


#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [x] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@akash-jain-10
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @shahsank3t -->
<!--- @sureshms @harshach -->
<!--- @ayush-shah @akash-jain-10 -->