### PR TITLE
fix: ldap configuration is not properly passed to authentication secret

### DIFF
--- a/charts/openmetadata/Chart.yaml
+++ b/charts/openmetadata/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.3.0
+version: 1.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openmetadata/Chart.yaml
+++ b/charts/openmetadata/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.3.1
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openmetadata/templates/secrets.yaml
+++ b/charts/openmetadata/templates/secrets.yaml
@@ -231,7 +231,7 @@ data:
   AUTHENTICATION_USER_GROUP_ATTR: {{ .ldapConfiguration.groupAttributeName | quote | b64enc }}
   AUTHENTICATION_USER_GROUP_ATTR_VALUE: {{ .ldapConfiguration.groupAttributeValue | quote | b64enc }}
   AUTHENTICATION_USER_GROUP_MEMBER_ATTR: {{ .ldapConfiguration.groupMemberAttributeName | quote | b64enc }}
-  AUTH_ROLES_MAPPING: {{ .authRolesMapping | quote | b64enc }}
+  AUTH_ROLES_MAPPING: {{ .ldapConfiguration.authRolesMapping | quote | b64enc }}
   AUTH_REASSIGN_ROLES: {{ include "OpenMetadata.commaJoinedQuotedEncodedList" (dict "value" .authReassignRoles) }}
   AUTHENTICATION_USER_MAIL_ATTR: {{ .ldapConfiguration.mailAttributeName | quote | b64enc }}
   AUTHENTICATION_LDAP_POOL_SIZE: {{ .ldapConfiguration.maxPoolSize | quote | b64enc }}

--- a/charts/openmetadata/templates/secrets.yaml
+++ b/charts/openmetadata/templates/secrets.yaml
@@ -224,13 +224,13 @@ data:
   AUTHENTICATION_LDAP_PORT: {{ .ldapConfiguration.port | quote | b64enc }}
   AUTHENTICATION_LOOKUP_ADMIN_DN: {{ .ldapConfiguration.dnAdminPrincipal | quote | b64enc }}
   AUTHENTICATION_USER_LOOKUP_BASEDN: {{ .ldapConfiguration.userBaseDN | quote | b64enc }}
-  AUTHENTICATION_GROUP_LOOKUP_BASEDN: {{ .groupBaseDN | quote | b64enc }}
-  AUTHENTICATION_USER_ROLE_ADMIN_NAME: {{ .roleAdminName | quote | b64enc }}
-  AUTHENTICATION_USER_ALL_ATTR: {{ .allAttributeName | quote | b64enc }}
-  AUTHENTICATION_USER_NAME_ATTR: {{ .usernameAttributeName | quote | b64enc }}
-  AUTHENTICATION_USER_GROUP_ATTR: {{ .groupAttributeName | quote | b64enc }}
-  AUTHENTICATION_USER_GROUP_ATTR_VALUE: {{ .groupAttributeValue | quote | b64enc }}
-  AUTHENTICATION_USER_GROUP_MEMBER_ATTR: {{ .groupMemberAttributeName | quote | b64enc }}
+  AUTHENTICATION_GROUP_LOOKUP_BASEDN: {{ .ldapConfiguration.groupBaseDN | quote | b64enc }}
+  AUTHENTICATION_USER_ROLE_ADMIN_NAME: {{ .ldapConfiguration.roleAdminName | quote | b64enc }}
+  AUTHENTICATION_USER_ALL_ATTR: {{ .ldapConfiguration.allAttributeName | quote | b64enc }}
+  AUTHENTICATION_USER_NAME_ATTR: {{ .ldapConfiguration.usernameAttributeName | quote | b64enc }}
+  AUTHENTICATION_USER_GROUP_ATTR: {{ .ldapConfiguration.groupAttributeName | quote | b64enc }}
+  AUTHENTICATION_USER_GROUP_ATTR_VALUE: {{ .ldapConfiguration.groupAttributeValue | quote | b64enc }}
+  AUTHENTICATION_USER_GROUP_MEMBER_ATTR: {{ .ldapConfiguration.groupMemberAttributeName | quote | b64enc }}
   AUTH_ROLES_MAPPING: {{ .authRolesMapping | quote | b64enc }}
   AUTH_REASSIGN_ROLES: {{ include "OpenMetadata.commaJoinedQuotedEncodedList" (dict "value" .authReassignRoles) }}
   AUTHENTICATION_USER_MAIL_ATTR: {{ .ldapConfiguration.mailAttributeName | quote | b64enc }}


### PR DESCRIPTION
### What this PR does / why we need it :
<!-- Explain what you have done & tag your assigned issue !-->
<!-- Which issue this PR fixes (if applicable) !-->
Fixes issue when deploying OM with ldap as authentication method.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @akash-jain-10 @tutte @dhruvinmaniar123 !-->