### PR TITLE
feat: Prepare Release 1.4.8

### DIFF
--- a/charts/deps/Chart.yaml
+++ b/charts/deps/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.4.7
+version: 1.4.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.4.7"
+appVersion: "1.4.8"
 
 home: https://open-metadata.org/
 

--- a/charts/deps/values.yaml
+++ b/charts/deps/values.yaml
@@ -61,7 +61,7 @@ airflow:
   airflow:
     image:
       repository: docker.getcollate.io/openmetadata/ingestion
-      tag: 1.4.7
+      tag: 1.4.8
       pullPolicy: "IfNotPresent"
     executor: "KubernetesExecutor"
     config:

--- a/charts/openmetadata/Chart.yaml
+++ b/charts/openmetadata/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.4.7
+version: 1.4.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.4.7"
+appVersion: "1.4.8"
 
 home: https://open-metadata.org/
 

--- a/charts/openmetadata/README.md
+++ b/charts/openmetadata/README.md
@@ -258,7 +258,7 @@ helm install openmetadata open-metadata/openmetadata --values <<path-to-values-f
 | fullnameOverride | string | `"openmetadata"` |
 | image.pullPolicy | string | `"Always"` |
 | image.repository | string | `"docker.getcollate.io/openmetadata/server"` |
-| image.tag | string | `1.4.7` |
+| image.tag | string | `1.4.8` |
 | imagePullSecrets | list | `[]` |
 | ingress.annotations | object | `{}` |
 | ingress.className | string | `""` |

--- a/charts/openmetadata/templates/_helpers.tpl
+++ b/charts/openmetadata/templates/_helpers.tpl
@@ -239,8 +239,17 @@ OpenMetadata Configurations Environment Variables*/}}
       key: {{ .secretKey }}
 {{- end }}
 {{- end }}
-{{- if or .Values.openmetadata.config.authentication.saml.security.wantAssertionEncrypted .Values.openmetadata.config.authentication.saml.security.wantNameIdEncrypted }}
-# Key Store should only be considered if either wantAssertionEncrypted or wantNameIdEncrypted will be true
+{{- if .Values.openmetadata.config.authentication.saml.sp.spPrivateKey.secretRef }}
+{{- with .Values.openmetadata.config.authentication.saml.sp.spPrivateKey }}
+- name: SAML_SP_PRIVATE_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .secretRef }}
+      key: {{ .secretKey }}
+{{- end }}
+{{- end }}
+{{- if .Values.openmetadata.config.authentication.saml.security.wantAssertionEncrypted }}
+# Key Store should only be considered if wantAssertionEncrypted will be true
 {{- if .Values.openmetadata.config.authentication.saml.security.keyStoreAlias.secretRef }}
 {{- with .Values.openmetadata.config.authentication.saml.security.keyStoreAlias }}
 - name: SAML_KEYSTORE_ALIAS

--- a/charts/openmetadata/templates/secrets.yaml
+++ b/charts/openmetadata/templates/secrets.yaml
@@ -286,6 +286,7 @@ data:
   SAML_SP_ACS: {{ .saml.sp.acs | quote | b64enc }}
   SAML_SP_CALLBACK: {{ .saml.sp.callback | quote | b64enc }}
   SAML_STRICT_MODE: {{ .saml.security.strictMode | quote | b64enc }}
+  SAML_VALIDATE_XML: {{ .saml.security.validateXml | quote | b64enc }}
   SAML_SP_TOKEN_VALIDITY: {{ .saml.security.tokenValidity | quote | b64enc }}
   SAML_SEND_ENCRYPTED_NAME_ID: {{ .saml.security.sendEncryptedNameId | quote | b64enc }}
   SAML_SEND_SIGNED_AUTH_REQUEST: {{ .saml.security.sendSignedAuthRequest | quote | b64enc }}
@@ -293,9 +294,8 @@ data:
   SAML_WANT_MESSAGE_SIGNED: {{ .saml.security.wantMessagesSigned | quote | b64enc }}
   SAML_WANT_ASSERTION_SIGNED: {{ .saml.security.wantAssertionsSigned | quote | b64enc }}
   SAML_WANT_ASSERTION_ENCRYPTED: {{ .saml.security.wantAssertionEncrypted | quote | b64enc }}
-  SAML_WANT_NAME_ID_ENCRYPTED: {{ .saml.security.wantNameIdEncrypted | quote | b64enc }}
-  # Key Store should only be considered if either wantAssertionEncrypted or wantNameIdEncrypted will be true
-  {{- if or .saml.security.wantAssertionEncrypted .saml.security.wantNameIdEncrypted }}
+  # Key Store should only be considered if wantAssertionEncrypted will be true
+  {{- if .saml.security.wantAssertionEncrypted }}
   SAML_KEYSTORE_FILE_PATH: {{ .saml.security.keyStoreFilePath | quote | b64enc }}
   {{ end }}
 {{ end }}

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -597,7 +597,7 @@
                                                 "strictMode": {
                                                     "type": "boolean"
                                                 },
-                                                "validatexml": {
+                                                "validateXml": {
                                                     "type": "boolean"
                                                 },
                                                 "tokenValidity": {

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -574,6 +574,17 @@
                                                         }
                                                     }
                                                 },
+                                                "spPrivateKey": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "secretRef": {
+                                                            "type": "string"
+                                                        },
+                                                        "secretKey": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                },
                                                 "callback": {
                                                     "type": "string"
                                                 }
@@ -584,6 +595,9 @@
                                             "additionalProperties": false,
                                             "properties": {
                                                 "strictMode": {
+                                                    "type": "boolean"
+                                                },
+                                                "validatexml": {
                                                     "type": "boolean"
                                                 },
                                                 "tokenValidity": {
@@ -605,9 +619,6 @@
                                                     "type": "boolean"
                                                 },
                                                 "wantAssertionEncrypted": {
-                                                    "type": "boolean"
-                                                },
-                                                "wantNameIdEncrypted": {
                                                     "type": "boolean"
                                                 },
                                                 "keyStoreFilePath": {

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -192,9 +192,13 @@ openmetadata:
           spX509Certificate:
             secretRef: ""
             secretKey: ""
+          spPrivateKey:
+            secretRef: ""
+            secretKey: ""
           callback: "http://openmetadata:8585/saml/callback"
         security:
           strictMode: false
+          validateXml: false
           tokenValidity: 3600
           sendEncryptedNameId: false
           sendSignedAuthRequest: false
@@ -202,7 +206,6 @@ openmetadata:
           wantMessagesSigned: false
           wantAssertionsSigned: false
           wantAssertionEncrypted: false
-          wantNameIdEncrypted: false
           keyStoreFilePath: ""
           keyStoreAlias:
             secretRef: ""


### PR DESCRIPTION
Preparing the Release 1.4.8 by doing the following:

- Update versions to `1.4.8`
- Add `spPrivateKey` to `values.yaml` as a secret
- Add `spPrivateKey` logic to `_helpers.tpl`
- Add `validateXml` to `values.yaml` as Boolean
- Add `validateXml` to `secrets.yaml` template
- Remove `wantNameIdEncrypted` from `secrets.yaml`
- Remove logic involving `wantNameIdEncrypted` from `_helpers.tpl`
- Update `values.schema.json` accordingly

These decisions were taken based on the following git diff
![image](https://github.com/user-attachments/assets/017e90db-7938-4f07-bf46-a662d71fe782)
