### PR TITLE
OpenMetadata - Change default bind address to 0.0.0.0

### DIFF
--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -16,7 +16,7 @@ openmetadata:
     logLevel: INFO
     clusterName: openmetadata
     openmetadata:
-      host: openmetadata
+      host: "0.0.0.0"
       # URI to use with OpenMetadata Alerts Integrations
       uri: "http://openmetadata:8585"
       port: 8585


### PR DESCRIPTION
### What this PR does / why we need it :
This PR will replace the default binding host to be `0.0.0.0` instead of the hostname, which can lead to problems in kubernetes.
Fixes https://github.com/open-metadata/openmetadata-helm-charts/issues/256

### Type of change :
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Documentation

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] All new and existing tests passed.

#
### Reviewers
@akash-jain-10