### PR TITLE
openmetadata: add nodeSelector, affinity and tolerations on test connection pod

### DIFF
--- a/charts/openmetadata/templates/tests/test-connection.yaml
+++ b/charts/openmetadata/templates/tests/test-connection.yaml
@@ -18,3 +18,14 @@ spec:
       command: ['wget']
       args: ['{{ include "OpenMetadata.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never
+  nodeSelector:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .Values.affinity }}
+  affinity:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .Values.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}


### PR DESCRIPTION
### What this PR does / why we need it :
<!-- Explain what you have done & tag your assigned issue !-->
<!-- Which issue this PR fixes (if applicable) !-->
In a cluster where all nodes use taint, test pod will fail to schedule and keep in Pending state. This PR will make sure that test pod will be scheduled on the same node as openmetadata server pod.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @akash-jain-10 @tutte @dhruvinmaniar123 !-->