### PR TITLE
CHORE - Add GCP to secretsManager.properties.provider enum

### DIFF
--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -1065,7 +1065,8 @@
                                         "managed-aws-ssm",
                                         "in-memory",
                                         "managed-azure-kv",
-                                        "azure-kv"
+                                        "azure-kv",
+                                        "gcp"
                                     ]
                                 },
                                 "prefix": {


### PR DESCRIPTION
### What this PR does / why we need it :
Add gcp (introduced [here](https://github.com/open-metadata/OpenMetadata/commit/9a31a352965333fdedb61886e3672a7240a11e59)) support in the secretsManager provider schema.

### Type of change :
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Documentation

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] All new and existing tests passed.

### Reviewers
@akash-jain-10 @pellejador 