### PR TITLE
ISSUE-304: allow running search reindexing fully with cronjob

### DIFF
--- a/charts/openmetadata/templates/cron-reindex.yaml
+++ b/charts/openmetadata/templates/cron-reindex.yaml
@@ -9,7 +9,7 @@ metadata:
         {{- toYaml . | nindent 8 }}  
     {{- end }}
 spec:
-  suspend: true
+  suspend: {{ .Values.openmetadata.config.reindexConfig.suspend }}
   failedJobsHistoryLimit: 1  
   successfulJobsHistoryLimit: 1 
   jobTemplate:
@@ -126,4 +126,4 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}                     
           restartPolicy: OnFailure
-  schedule: "0/5 * * * *"
+  schedule: {{ .Values.openmetadata.config.reindexConfig.schedule }}

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -188,6 +188,13 @@
                                 },
                                 "debug": {
                                     "type": "boolean"
+                                },
+                                "schedule": {
+                                    "type": "string"
+                                },
+                                "suspend": {
+                                    "type": "boolean",
+                                    "default": true
                                 }
                             }
                         },

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -14,11 +14,15 @@ openmetadata:
       additionalArgs: ""
     deployPipelinesConfig:
       debug: false
+      # You can pass the additional argument flags to the openmetadata-ops.sh reindex command
       additionalArgs: ""
     reindexConfig:
       debug: false
+      # You can choose whether to run the job on demand or on schedule.
+      suspend: true
       # You can pass the additional argument flags to the openmetadata-ops.sh reindex command
       additionalArgs: ""
+      schedule: "0/5 * * * *"
     # Values can be OFF, ERROR, WARN, INFO, DEBUG, TRACE, or ALL
     logLevel: INFO
     clusterName: openmetadata


### PR DESCRIPTION
Allow running elastic search reindexing fully from the cronjob process, this will mitigate potential issues with the server being affected when issues happen there, example OOMs, or issues on the search server side.

### What this PR does / why we need it :
<!-- Explain what you have done & tag your assigned issue !-->
<!-- Which issue this PR fixes (if applicable) !-->
Fixes #

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @akash-jain-10 @tutte @dhruvinmaniar123 !-->