### PR TITLE
Feat: Add horizontal pod autoscaling support

### DIFF
--- a/charts/openmetadata/templates/hpa.yml
+++ b/charts/openmetadata/templates/hpa.yml
@@ -1,0 +1,30 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "OpenMetadata.fullname" . }}-hpa
+  labels:
+    {{- include "OpenMetadata.labels" . | indent 4 }}
+  {{- with .Values.podAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "OpenMetadata.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.metricsTarget.averageCPUUtilization }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.metricsTarget.averageMemoryUtilization }}

--- a/charts/openmetadata/templates/hpa.yml
+++ b/charts/openmetadata/templates/hpa.yml
@@ -16,6 +16,10 @@ spec:
     name: {{ include "OpenMetadata.fullname" . }}
   minReplicas: {{ .Values.hpa.minReplicas }}
   maxReplicas: {{ .Values.hpa.maxReplicas }}
+  {{- with .Values.hpa.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   metrics:
     {{- toYaml .Values.hpa.metrics | nindent 4 }}
 {{- end }}

--- a/charts/openmetadata/templates/hpa.yml
+++ b/charts/openmetadata/templates/hpa.yml
@@ -1,5 +1,5 @@
 {{- if .Values.hpa.enabled -}}
-apiVersion: autoscaling/v2
+apiVersion: {{ .Values.hpa.apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "OpenMetadata.fullname" . }}-hpa

--- a/charts/openmetadata/templates/hpa.yml
+++ b/charts/openmetadata/templates/hpa.yml
@@ -1,3 +1,4 @@
+{{- if .Values.hpa.enabled -}}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -28,3 +29,4 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.hpa.metricsTarget.averageMemoryUtilization }}
+{{- end }}

--- a/charts/openmetadata/templates/hpa.yml
+++ b/charts/openmetadata/templates/hpa.yml
@@ -17,16 +17,5 @@ spec:
   minReplicas: {{ .Values.hpa.minReplicas }}
   maxReplicas: {{ .Values.hpa.maxReplicas }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.hpa.metricsTarget.averageCPUUtilization }}
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.hpa.metricsTarget.averageMemoryUtilization }}
+    {{- toYaml .Values.hpa.metrics | nindent 4 }}
 {{- end }}

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -1408,6 +1408,9 @@
         "maxReplicas": {
           "type": "number"
         },
+        "behavior": {
+          "type": "object"
+        },
         "metrics": {
           "type": "array",
           "items": {

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -1419,20 +1419,10 @@
               "type": {
                 "type": "string"
               }
-            },
-            "required": [
-              "type"
-            ]
+            }
           }
         }
-      },
-      "required": [
-        "enabled",
-        "apiVersion",
-        "minReplicas",
-        "maxReplicas",
-        "metrics"
-      ]
+      }
     }
   }
 }

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -1391,6 +1391,45 @@
           "type": "boolean"
         }
       }
+    },
+    "hpa": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "apiVersion": {
+          "type": "string"
+        },
+        "minReplicas": {
+          "type": "number"
+        },
+        "maxReplicas": {
+          "type": "number"
+        },
+        "metrics": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        }
+      },
+      "required": [
+        "enabled",
+        "apiVersion",
+        "minReplicas",
+        "maxReplicas",
+        "metrics"
+      ]
     }
   }
 }

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -530,6 +530,7 @@ hpa:
   apiVersion: autoscaling/v2
   minReplicas: 1
   maxReplicas: 5
+  behavior: {}
   metrics:
   - type: Resource
     resource:

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -527,6 +527,7 @@ podAnnotations: {}
 # 2. Define resource request and limits for the pods
 hpa:
   enabled: false
+  apiVersion: autoscaling/v2
   minReplicas: 1
   maxReplicas: 5
   metrics:

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -474,14 +474,15 @@ preMigrateInitContainers: []
 resources: {}
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
-# resources, such as Minikube. If you do want to specify resources, uncomment the following
-# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+# resources, such as Minikube.The resources configuration is mandatory to enable autoscaling.
+# To specify resources, uncomment the following lines, adjust them as necessary, and remove
+# the curly braces after 'resources:'.
 # limits:
 #   cpu: 1
 #   memory: 2048Mi
 # requests:
 #   cpu: 500m
-#   memory: 256Mi
+#   memory: 1024Mi
 
 nodeSelector: {}
 
@@ -521,6 +522,7 @@ commonLabels: {}
 deploymentAnnotations: {}
 podAnnotations: {}
 
+# If you enable hpa, make sure to define resource requests and limits for the pods.
 hpa:
   enabled: true
   minReplicas: 1

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -477,12 +477,12 @@ resources: {}
 # resources, such as Minikube.The resources configuration is required to enable autoscaling.
 # To specify resources, uncomment the following lines, adjust them as necessary, and remove
 # the curly braces after 'resources:'.
-# limits:
-#   cpu: 1
-#   memory: 2048Mi
-# requests:
-#   cpu: 500m
-#   memory: 1024Mi
+#   limits:
+#     cpu: 1
+#     memory: 2048Mi
+#   requests:
+#     cpu: 500m
+#     memory: 1024Mi
 
 nodeSelector: {}
 
@@ -526,7 +526,7 @@ podAnnotations: {}
 # 1. Install metrics-server (https://github.com/kubernetes-sigs/metrics-server)
 # 2. Define resource request and limits for the pods
 hpa:
-  enabled: true
+  enabled: false
   minReplicas: 1
   maxReplicas: 5
   metrics:

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -471,17 +471,13 @@ extraInitContainers: []
 # Provision for InitContainers to be running before the `run-db-migration` InitContainer
 preMigrateInitContainers: []
 
-resources: {}
-# We usually recommend not to specify default resources and to leave this as a conscious
-# choice for the user. This also increases chances charts run on environments with little
-# resources, such as Minikube. If you do want to specify resources, uncomment the following
-# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-# limits:
-#   cpu: 1
-#   memory: 2048Mi
-# requests:
-#   cpu: 500m
-#   memory: 256Mi
+resources:
+  limits:
+    cpu: 1
+    memory: 2048Mi
+  requests:
+    cpu: 500m
+    memory: 1024Mi
 
 nodeSelector: {}
 
@@ -520,3 +516,11 @@ podDisruptionBudget:
 commonLabels: {}
 deploymentAnnotations: {}
 podAnnotations: {}
+
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  metricsTarget:
+    averageCPUUtilization: 80
+    averageMemoryUtilization: 80

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -474,7 +474,7 @@ preMigrateInitContainers: []
 resources: {}
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
-# resources, such as Minikube.The resources configuration is mandatory to enable autoscaling.
+# resources, such as Minikube.The resources configuration is required to enable autoscaling.
 # To specify resources, uncomment the following lines, adjust them as necessary, and remove
 # the curly braces after 'resources:'.
 # limits:
@@ -522,7 +522,9 @@ commonLabels: {}
 deploymentAnnotations: {}
 podAnnotations: {}
 
-# If you enable hpa, make sure to define resource requests and limits for the pods.
+# Prerequisites for enabling Horizontal Pod Autoscaler (HPA):
+# 1. Install metrics-server (https://github.com/kubernetes-sigs/metrics-server)
+# 2. Define resource request and limits for the pods
 hpa:
   enabled: true
   minReplicas: 1

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -518,9 +518,19 @@ deploymentAnnotations: {}
 podAnnotations: {}
 
 hpa:
-  enabled: false
+  enabled: true
   minReplicas: 1
   maxReplicas: 5
-  metricsTarget:
-    averageCPUUtilization: 80
-    averageMemoryUtilization: 80
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -471,13 +471,17 @@ extraInitContainers: []
 # Provision for InitContainers to be running before the `run-db-migration` InitContainer
 preMigrateInitContainers: []
 
-resources:
-  limits:
-    cpu: 1
-    memory: 2048Mi
-  requests:
-    cpu: 500m
-    memory: 1024Mi
+resources: {}
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+# limits:
+#   cpu: 1
+#   memory: 2048Mi
+# requests:
+#   cpu: 500m
+#   memory: 256Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
### What this PR does / why we need it :
This PR adds support for [Horizontal Pod Autoscaling (HPA)](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) for the OpenMetadata deployment. The default HPA metrics target CPU and memory utilization to scale the pods accordingly. By default, HPA is disabled in the values.yaml file.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @akash-jain-10 @tutte @dhruvinmaniar123 !-->