### PR TITLE
openmetadata: Add startingDeadlineSeconds to cronjob in OpenMetadata Helm charts to support OpenShift policies

### DIFF
--- a/charts/openmetadata/README.md
+++ b/charts/openmetadata/README.md
@@ -283,6 +283,7 @@ helm install openmetadata open-metadata/openmetadata --values <<path-to-values-f
 | readinessProbe.httpGet.port | string | `http` |
 | replicaCount | int | `1` |
 | resources | object | `{}` |
+| startingDeadlineSeconds | int | `100` |
 | securityContext | object | `{}` |
 | service.adminPort | string | `8586` |
 | service.annotations | object | `{}` |

--- a/charts/openmetadata/templates/cron-deploy-pipelines.yaml
+++ b/charts/openmetadata/templates/cron-deploy-pipelines.yaml
@@ -123,6 +123,6 @@ spec:
           {{- end }}                     
           restartPolicy: OnFailure
   schedule: "0/5 * * * *"
-  {{- if .Values.startingDeadlineSeconds }}
+  {{- if ne .Values.startingDeadlineSeconds nil }}
   startingDeadlineSeconds: {{ .Values.startingDeadlineSeconds }}
   {{- end }}

--- a/charts/openmetadata/templates/cron-deploy-pipelines.yaml
+++ b/charts/openmetadata/templates/cron-deploy-pipelines.yaml
@@ -123,3 +123,6 @@ spec:
           {{- end }}                     
           restartPolicy: OnFailure
   schedule: "0/5 * * * *"
+  {{- if .Values.startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ .Values.startingDeadlineSeconds }}
+  {{- end }}

--- a/charts/openmetadata/templates/cron-reindex.yaml
+++ b/charts/openmetadata/templates/cron-reindex.yaml
@@ -123,6 +123,6 @@ spec:
           {{- end }}                     
           restartPolicy: OnFailure
   schedule: "0/5 * * * *"
-  {{- if .Values.startingDeadlineSeconds }}
+  {{- if ne .Values.startingDeadlineSeconds nil }}
   startingDeadlineSeconds: {{ .Values.startingDeadlineSeconds }}
   {{- end }}

--- a/charts/openmetadata/templates/cron-reindex.yaml
+++ b/charts/openmetadata/templates/cron-reindex.yaml
@@ -123,3 +123,6 @@ spec:
           {{- end }}                     
           restartPolicy: OnFailure
   schedule: "0/5 * * * *"
+  {{- if .Values.startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ .Values.startingDeadlineSeconds }}
+  {{- end }}

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -1261,6 +1261,9 @@
     "resources": {
       "type": "object"
     },
+    "startingDeadlineSeconds": {
+      "type": "number"
+    },
     "securityContext": {
       "type": "object"
     },

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -476,6 +476,8 @@ resources: {}
 #     cpu: 500m
 #     memory: 1024Mi
 
+startingDeadlineSeconds: 100
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION

### What this PR does / why we need it :
<!-- Explain what you have done & tag your assigned issue !-->
<!-- Which issue this PR fixes (if applicable) !-->
Added conditional inclusion of startingDeadlineSeconds to cronjob in OpenMetadata Helm charts to support OpenShift policies.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @akash-jain-10 @tutte @dhruvinmaniar123 !-->