### PR TITLE
CHORE - Remove setting deprecated OM_URI envvar

### DIFF
--- a/charts/openmetadata/templates/secrets.yaml
+++ b/charts/openmetadata/templates/secrets.yaml
@@ -121,7 +121,6 @@ type: Opaque
 data:
 {{- with .Values.openmetadata.config.openmetadata }}
   SERVER_HOST: {{ .host | b64enc }}
-  OM_URI: {{ .uri | quote | b64enc }}
   SERVER_PORT: {{ .port | quote | b64enc }}
   SERVER_ADMIN_PORT: {{ .adminPort | quote | b64enc }}
   SERVER_MAX_THREADS: {{ .maxThreads | quote | b64enc }}

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -992,9 +992,6 @@
                 "port": {
                   "type": "integer"
                 },
-                "uri": {
-                  "type": "string"
-                },
                 "maxThreads": {
                   "type": "integer"
                 },

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -24,8 +24,6 @@ openmetadata:
     clusterName: openmetadata
     openmetadata:
       host: "0.0.0.0"
-      # URI to use with OpenMetadata Alerts Integrations
-      uri: "http://openmetadata:8585"
       port: 8585
       adminPort: 8586
       maxThreads: 50


### PR DESCRIPTION
### What this PR does / why we need it :
Remove deprecated OM_URI environment variable, which was removed in release 1.3.0 ([commit](https://github.com/open-metadata/OpenMetadata/commit/2ae0333551487929b40398f1acf94a91bc048b8d)).

#
### Type of change :
- [x] Deprecation
- [ ] Improvement
- [ ] New feature
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] All new and existing tests passed.
