### PR TITLE
openmetadata: expose resource requests and limits for test-connection pod

### DIFF
--- a/charts/openmetadata/Chart.yaml
+++ b/charts/openmetadata/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.9.5
+version: 1.9.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openmetadata/Chart.yaml
+++ b/charts/openmetadata/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.9.4
+version: 1.9.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openmetadata/README.md
+++ b/charts/openmetadata/README.md
@@ -286,6 +286,7 @@ helm install openmetadata open-metadata/openmetadata --values <<path-to-values-f
 | replicaCount | int | `1` |
 | resources | object | `{}` |
 | startingDeadlineSeconds | int | `100` |
+| testConnection.resources | object | `{}` |
 | securityContext | object | `{}` |
 | service.adminPort | string | `8586` |
 | service.annotations | object | `{}` |

--- a/charts/openmetadata/templates/tests/test-connection.yaml
+++ b/charts/openmetadata/templates/tests/test-connection.yaml
@@ -22,15 +22,15 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
   restartPolicy: Never
-{{- with .Values.nodeSelector }}
+  {{- with .Values.nodeSelector }}
   nodeSelector:
-    {{- toYaml . | nindent 4 }}
-{{- end }}
-{{- with .Values.affinity }}
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .Values.affinity }}
   affinity:
-    {{- toYaml . | nindent 4 }}
-{{- end }}
-{{- with .Values.tolerations }}
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .Values.tolerations }}
   tolerations:
-    {{- toYaml . | nindent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 8 }}
+  {{- end }}

--- a/charts/openmetadata/templates/tests/test-connection.yaml
+++ b/charts/openmetadata/templates/tests/test-connection.yaml
@@ -17,16 +17,20 @@ spec:
       image: busybox
       command: ['wget']
       args: ['{{ include "OpenMetadata.fullname" . }}:{{ .Values.service.port }}']
+      {{- with .Values.testConnection.resources }}
+      resources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   restartPolicy: Never
-  {{- with .Values.nodeSelector }}
+{{- with .Values.nodeSelector }}
   nodeSelector:
-    {{- toYaml . | nindent 8 }}
-  {{- end }}
-  {{- with .Values.affinity }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.affinity }}
   affinity:
-    {{- toYaml . | nindent 8 }}
-  {{- end }}
-  {{- with .Values.tolerations }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.tolerations }}
   tolerations:
-    {{- toYaml . | nindent 8 }}
-  {{- end }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -1270,6 +1270,15 @@
     "startingDeadlineSeconds": {
       "type": "number"
     },
+    "testConnection": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resources": {
+          "type": "object"
+        }
+      }
+    },
     "securityContext": {
       "type": "object"
     },

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -481,6 +481,21 @@ resources: {}
 
 startingDeadlineSeconds: 100
 
+# Test connection pod configuration
+testConnection:
+  resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube.
+  # To specify resources, uncomment the following lines, adjust them as necessary, and remove
+  # the curly braces after 'resources:'.
+  #   limits:
+  #     cpu: 100m
+  #     memory: 128Mi
+  #   requests:
+  #     cpu: 50m
+  #     memory: 64Mi
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
### What this PR does / why we need it :

This change allows the use of HPA for OpenMetadata. 
Currently, this is not possible because the HPA cannot calculate the metrics because no resource requests (and limits?) are set for the pod `openmetadata-test-connection`:

```
Name:                                                     openmetadata-hpa
Namespace:                                                data
Labels:                                                   app=openmetadata
                                                          app.kubernetes.io/instance=openmetadata
                                                          app.kubernetes.io/managed-by=Helm
                                                          app.kubernetes.io/name=openmetadata
                                                          app.kubernetes.io/version=1.9.1
                                                          helm.sh/chart=openmetadata-1.9.1
                                                          kustomize.toolkit.fluxcd.io/name=data-cdk8s
                                                          kustomize.toolkit.fluxcd.io/namespace=flux-system
Annotations:                                              europace.de/logging_index: eks_data_openmetadata_ps
CreationTimestamp:                                        Fri, 22 Aug 2025 15:44:16 +0200
Reference:                                                Deployment/openmetadata
Metrics:                                                  ( current / target )
  resource cpu on pods  (as a percentage of request):     <unknown> / 80%
  resource memory on pods  (as a percentage of request):  <unknown> / 80%
Min replicas:                                             1
Max replicas:                                             5
Deployment pods:                                          1 current / 1 desired
Conditions:
  Type            Status  Reason                   Message
  ----            ------  ------                   -------
  AbleToScale     True    SucceededGetScale        the HPA controller was able to get the target's current scale
  ScalingActive   False   FailedGetResourceMetric  the HPA was unable to compute the replica count: failed to get cpu utilization: missing request for cpu in container wget of Pod openmetadata-test-connection
  ScalingLimited  False   DesiredWithinRange       the desired count is within the acceptable range
Events:
  Type     Reason                   Age                        From                       Message
  ----     ------                   ----                       ----                       -------
  Warning  FailedGetResourceMetric  3m24s (x26443 over 4d15h)  horizontal-pod-autoscaler  failed to get cpu utilization: missing request for cpu in container wget of Pod openmetadata-test-connection
```



#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name
- [?] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @akash-jain-10 @tutte @dhruvinmaniar123 !-->