### PR TITLE
fix: exclude replicas from deployment if hpa

### DIFF
--- a/charts/openmetadata/templates/deployment.yaml
+++ b/charts/openmetadata/templates/deployment.yaml
@@ -9,7 +9,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.hpa.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "OpenMetadata.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
### What this PR does / why we need it :
<!-- Explain what you have done & tag your assigned issue !-->
<!-- Which issue this PR fixes (if applicable) !-->

Previously, `hpa` would not work because with a replica set explicity, the deployment would kill any spawned pod beyond the limit set by replica. With a value of 1 this would break hpa entirely. Moving forward, the deployment will not contain a value set for replicas but instead have hpa take care of scaling if hpa is enable.d

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @akash-jain-10 @tutte @dhruvinmaniar123 !-->