### PR TITLE
openmetadata: Add ability to disable `deploy-pipelines` and `reindex` cronjobs in `values.yaml` file

### DIFF
--- a/charts/openmetadata/README.md
+++ b/charts/openmetadata/README.md
@@ -311,5 +311,5 @@ helm install openmetadata open-metadata/openmetadata --values <<path-to-values-f
 | podDisruptionBudget.enabled | bool | `false` |
 | podDisruptionBudget.config.maxUnavailable | String | `1` |
 | podDisruptionBudget.config.minAvailable | String | `1` |
-| cronjobs.deployPipelines.enabled | bool | `true` |
-| cronjobs.reindex.enabled | bool | `true` |
+| openmetadata.config.deployPipelinesConfig.enabled | bool | `true` |
+| openmetadata.config.reindexConfig.enabled | bool | `true` |

--- a/charts/openmetadata/templates/cron-deploy-pipelines.yaml
+++ b/charts/openmetadata/templates/cron-deploy-pipelines.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cronjobs.deployPipelines.enabled }}
+{{- if .Values.openmetadata.config.deployPipelinesConfig.enabled }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/charts/openmetadata/templates/cron-reindex.yaml
+++ b/charts/openmetadata/templates/cron-reindex.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cronjobs.reindex.enabled }}
+{{- if .Values.openmetadata.config.reindexConfig.enabled }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -171,6 +171,9 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
                 "additionalArgs": {
                   "type": "string"
                 },
@@ -183,6 +186,9 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
                 "additionalArgs": {
                   "type": "string"
                 },
@@ -1408,30 +1414,6 @@
               "type": {
                 "type": "string"
               }
-            }
-          }
-        }
-      }
-    },
-    "cronjobs": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "deployPipelines": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "enabled": {
-              "type": "boolean"
-            }
-          }
-        },
-        "reindex": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "enabled": {
-              "type": "boolean"
             }
           }
         }

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -13,9 +13,11 @@ openmetadata:
       # Example if you want to force migration runs, use additionalArgs: "--force"
       additionalArgs: ""
     deployPipelinesConfig:
+      enabled: true
       debug: false
       additionalArgs: ""
     reindexConfig:
+      enabled: true
       debug: false
       # You can pass the additional argument flags to the openmetadata-ops.sh reindex command
       additionalArgs: ""
@@ -478,15 +480,6 @@ resources: {}
 #     memory: 1024Mi
 
 startingDeadlineSeconds: 100
-
-# Cronjob configuration
-cronjobs:
-  # Enable/disable deploy-pipelines cronjob
-  deployPipelines:
-    enabled: true
-  # Enable/disable reindex cronjob
-  reindex:
-    enabled: true
 
 # Test connection pod configuration
 testConnection:


### PR DESCRIPTION


### What this PR does / why we need it :
<!-- Explain what you have done & tag your assigned issue !-->
<!-- Which issue this PR fixes (if applicable) !-->
Add two new configs `cronjobs.deployPipelines.enabled` and `cronjobs.reindex.enabled` to control whether we need those cronjobs for maintenance ops for not. The default is `true` which maintains backward compatibility with previous version

Fixes https://github.com/open-metadata/openmetadata-helm-charts/issues/387

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @akash-jain-10 @tutte @dhruvinmaniar123 !-->