### PR TITLE
feat(deps chart): add the possibility to have extra labels for the custom cronJob

### DIFF
--- a/charts/deps/templates/_helpers.tpl
+++ b/charts/deps/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/*
+Common labels
+*/}}
+{{- define "OpenMetadataDeps.labels" -}}
+app: {{ include "airflow.labels.app" . }}
+component: logs-cleanup
+chart: {{ include "airflow.labels.chart" . }}
+release: {{ .Release.Name }}
+heritage: {{ .Release.Service }}
+{{- with .Values.cronJobLabels }}
+{{ toYaml .}}
+{{- end }}
+{{- end }}

--- a/charts/deps/templates/cron-airflow-logs-cleanup.yaml
+++ b/charts/deps/templates/cron-airflow-logs-cleanup.yaml
@@ -19,17 +19,14 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "airflow.fullname" . }}-airflow-logs-cleanup
-  labels:
-    app: {{ include "airflow.labels.app" . }}
-    component: logs-cleanup
-    chart: {{ include "airflow.labels.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+  labels: {{- include "OpenMetadataDeps.labels" . | nindent 4 }}
 spec:
   schedule: "{{ .Values.airflow.logs.persistence.cleanup.schedule }}"
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels: {{- include "OpenMetadataDeps.labels" . | nindent 12 }}
         spec:
           containers:
           - name: logs-cleanup

--- a/charts/deps/values.yaml
+++ b/charts/deps/values.yaml
@@ -8,6 +8,8 @@ global:
   security:
     allowInsecureImages: true
 
+cronJobLabels: {}
+
 mysql:
   enabled: true
   fullnameOverride: "mysql"


### PR DESCRIPTION
### What this PR does / why we need it :
Today, it's not possible to add extralabels to the embedded/custom cronjob for airflow logs cleanup.

#
### Type of change :
- [x] New feature

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have tested my code
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @akash-jain-10 @tutte @dhruvinmaniar123 !-->
helm template command result 
```yaml
---
# Source: openmetadata-dependencies/templates/cron-airflow-logs-cleanup.yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  name: toto-airflow-logs-cleanup
  labels:
    app: openmetadata-dependencies
    component: logs-cleanup
    chart: openmetadata-dependencies-1.9.12
    release: toto
    heritage: Helm
    test: customlabel
spec:
  schedule: "0 4 * * *"
  jobTemplate:
    spec:
      template:
        metadata:
          labels:
            app: openmetadata-dependencies
            component: logs-cleanup
            chart: openmetadata-dependencies-1.9.12
            release: toto
            heritage: Helm
            test: customlabel
        spec:
          containers:
          - name: logs-cleanup
            image: busybox:latest
            command:
              - sh
              - -c
              - |
                find /var/logs -type f -mtime +180 -exec rm -f {} \;
            volumeMounts:
              - name: logs-data
                mountPath: /var/logs
          restartPolicy: OnFailure
          volumes:
            - name: dags-data
              persistentVolumeClaim:
                claimName: toto-dags
            - name: logs-data
              persistentVolumeClaim:
                claimName: toto-logs
``` 