### PR TITLE
openmetadata: Do not print empty securityContext and podSecurityContext

### DIFF
--- a/charts/openmetadata/templates/cron-deploy-pipelines.yaml
+++ b/charts/openmetadata/templates/cron-deploy-pipelines.yaml
@@ -34,14 +34,18 @@ spec:
           {{- if not (.Values.automountServiceAccountToken) }}
           automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
           {{- end }}
+          {{- with .Values.podSecurityContext }}
           securityContext:
-            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumes:
           {{- include "tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 12 }}
           containers:
           - name: cron-deploy-pipelines
+            {{- with .Values.securityContext }}
             securityContext:
-              {{- toYaml .Values.securityContext | nindent 14 }}
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             volumeMounts:

--- a/charts/openmetadata/templates/cron-reindex.yaml
+++ b/charts/openmetadata/templates/cron-reindex.yaml
@@ -34,14 +34,18 @@ spec:
           {{- if not (.Values.automountServiceAccountToken) }}
           automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
           {{- end }}
+          {{- with .Values.podSecurityContext }}
           securityContext:  
-            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumes:
           {{- include "tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 12 }}
           containers:
           - name: cron-reindex
+            {{- with .Values.securityContext }}
             securityContext:
-              {{- toYaml .Values.securityContext | nindent 14 }}
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             volumeMounts:

--- a/charts/openmetadata/templates/deployment.yaml
+++ b/charts/openmetadata/templates/deployment.yaml
@@ -32,15 +32,19 @@ spec:
       {{- if not (.Values.automountServiceAccountToken) }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
       {{- with .Values.preMigrateInitContainers }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
       - name: run-db-migrations
+        {{- with .Values.securityContext }}
         securityContext:
-          {{- toYaml .Values.securityContext | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{ include "OpenMetadata.buildUpgradeCommand" .  | nindent 8 }}
@@ -116,8 +120,10 @@ spec:
       {{- include "tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:

--- a/charts/openmetadata/templates/tests/test-connection.yaml
+++ b/charts/openmetadata/templates/tests/test-connection.yaml
@@ -8,12 +8,16 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
+  {{- with .Values.podSecurityContext }}
   securityContext:
-    {{- toYaml .Values.podSecurityContext | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   containers:
     - name: wget
+      {{- with .Values.securityContext }}
       securityContext:
-        {{- toYaml .Values.securityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       image: busybox
       command: ['wget']
       args: ['{{ include "OpenMetadata.fullname" . }}:{{ .Values.service.port }}']


### PR DESCRIPTION
### What this PR does / why we need it :
The PR improves templates to avoid printing empty `securityContext` and `podSecurityContext` if the properties are empty.

#### Testing
Render the chart with the default values and verify that there are no empty `securityContext`.
```bash
helm template charts/openmetadata
```

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] All new and existing tests passed.

#
### Reviewers
@akash-jain-10
@tutte