### PR TITLE
openmetadata : Do not print empty resources

### DIFF
--- a/charts/openmetadata/templates/cron-deploy-pipelines.yaml
+++ b/charts/openmetadata/templates/cron-deploy-pipelines.yaml
@@ -109,8 +109,10 @@ spec:
             {{- with .Values.envFrom }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- with .Values.resources }}
             resources:
-              {{- toYaml .Values.resources | nindent 14 }}
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
           {{- if .Values.sidecars }}
             {{- include "tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 10 }}
           {{- end }}

--- a/charts/openmetadata/templates/cron-reindex.yaml
+++ b/charts/openmetadata/templates/cron-reindex.yaml
@@ -109,8 +109,10 @@ spec:
               {{- with .Values.envFrom }}
                 {{- toYaml . | nindent 14 }}
               {{- end }}
+            {{- with .Values.resources }}
             resources:
-              {{- toYaml .Values.resources | nindent 14 }}
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
           {{- if .Values.sidecars }}
             {{- include "tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 10 }}
           {{- end }}

--- a/charts/openmetadata/templates/deployment.yaml
+++ b/charts/openmetadata/templates/deployment.yaml
@@ -52,8 +52,10 @@ spec:
           {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
+        {{- with .Values.resources }}
         resources:
-          {{- toYaml .Values.resources | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         envFrom:
           - secretRef:
               name: {{ include "OpenMetadata.fullname" . }}-config-secret
@@ -198,8 +200,10 @@ spec:
             {{- with .Values.envFrom }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- if .Values.sidecars }}
           {{- include "tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
### What this PR does / why we need it :
The PR improves templates to avoid printing `resources` if the property value is empty.
Similar to PR https://github.com/open-metadata/openmetadata-helm-charts/pull/398 and the pattern already used in [tests/test-connection.yaml](https://github.com/open-metadata/openmetadata-helm-charts/blob/c3a435236a4ed3f0af9191111719b1dc146a1cc8/charts/openmetadata/templates/tests/test-connection.yaml#L24-L27).

#### Testing
Render the chart with the default values and verify that there are no empty `resources`.
```bash
helm template charts/openmetadata
```

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] All new and existing tests passed.

#
### Reviewers
@akash-jain-10