### PR TITLE
chore: Bump opensearch version to `3.3.2` in Chart.lock and Chart.yaml

### DIFF
--- a/charts/deps/Chart.lock
+++ b/charts/deps/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.18.0
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts/
-  version: 2.35.0
-digest: sha256:cf06186bfc786260eb13cccbf813bf074bdb68d6dd4d7d064643d5456c52ecfb
-generated: "2025-12-16T12:59:18.350819+05:30"
+  version: 3.3.2
+digest: sha256:94f8e65e4e65e50751e7885c424a97a3e4e543cd5fcb3e4fb5e9cb423fced69d
+generated: "2026-02-09T10:47:40.254231+05:30"

--- a/charts/deps/Chart.yaml
+++ b/charts/deps/Chart.yaml
@@ -67,6 +67,6 @@ dependencies:
   repository: "https://airflow.apache.org"
   condition: airflow.enabled
 - name: opensearch
-  version: "2.35.0"
+  version: "3.3.2"
   repository: "https://opensearch-project.github.io/helm-charts/"
   condition: opensearch.enabled


### PR DESCRIPTION
### What this PR does / why we need it :
<!-- Explain what you have done & tag your assigned issue !-->
<!-- Which issue this PR fixes (if applicable) !-->
Bump OpenSearch to `3.3.2`
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @akash-jain-10 @tutte @dhruvinmaniar123 !-->