### PR TITLE
fix: remove duplicate app.kubernetes.io/name label in k8s-pipeline-rbac.yaml

### DIFF
--- a/charts/openmetadata/templates/k8s-pipeline-rbac.yaml
+++ b/charts/openmetadata/templates/k8s-pipeline-rbac.yaml
@@ -8,7 +8,6 @@ metadata:
   name: {{ .Values.openmetadata.config.pipelineServiceClientConfig.k8s.serviceAccountName }}
   namespace: {{ $namespace }}
   labels:
-    app.kubernetes.io/name: openmetadata
     app.kubernetes.io/component: ingestion
     {{- include "OpenMetadata.labels" . | nindent 4 }}
   annotations:
@@ -22,7 +21,6 @@ metadata:
   name: {{ .Values.openmetadata.config.pipelineServiceClientConfig.k8s.serviceAccountName }}
   namespace: {{ $namespace }}
   labels:
-    app.kubernetes.io/name: openmetadata
     app.kubernetes.io/component: ingestion
     {{- include "OpenMetadata.labels" . | nindent 4 }}
 rules:
@@ -53,7 +51,6 @@ metadata:
   name: {{ .Values.openmetadata.config.pipelineServiceClientConfig.k8s.serviceAccountName }}
   namespace: {{ $namespace }}
   labels:
-    app.kubernetes.io/name: openmetadata
     app.kubernetes.io/component: ingestion
     {{- include "OpenMetadata.labels" . | nindent 4 }}
 subjects:
@@ -72,7 +69,6 @@ metadata:
   name: openmetadata-server-pipeline-manager
   namespace: {{ $namespace }}
   labels:
-    app.kubernetes.io/name: openmetadata
     app.kubernetes.io/component: server
     {{- include "OpenMetadata.labels" . | nindent 4 }}
 rules:
@@ -118,7 +114,6 @@ metadata:
   name: openmetadata-server-pipeline-manager
   namespace: {{ $namespace }}
   labels:
-    app.kubernetes.io/name: openmetadata
     app.kubernetes.io/component: server
     {{- include "OpenMetadata.labels" . | nindent 4 }}
 subjects:


### PR DESCRIPTION
## Summary

Fixes #463

The label `app.kubernetes.io/name` was hardcoded directly in the `labels` block of all 5 resources (ServiceAccount, Role ×2, RoleBinding ×2) in `k8s-pipeline-rbac.yaml`, while the included `OpenMetadata.labels` helper already emits the same key via `OpenMetadata.selectorLabels`. This produced a duplicate YAML mapping key, causing `helm install`/`helm upgrade` failures on OpenShift and EKS when using the K8sPipelineClient (`type: k8s`):

```
line 11: mapping key "app.kubernetes.io/name" already defined at line 8
```

**Fix:** Remove the 5 hardcoded `app.kubernetes.io/name: openmetadata` lines and let the value flow correctly through the `OpenMetadata.labels` helper. The `app.kubernetes.io/component` label (`ingestion`/`server`) is preserved as it is not emitted by the helper.

## Changes

- `charts/openmetadata/templates/k8s-pipeline-rbac.yaml` — removed hardcoded `app.kubernetes.io/name: openmetadata` from all 5 resource label blocks (lines 11, 25, 56, 75, 121)

## Additional finding

The hardcoded label was also **wrong** when `nameOverride` is set — `main` produced two conflicting values (`openmetadata` + the override) in the same labels block. The fix makes the label correctly reflect `nameOverride`.

## Test plan

- [x] `helm lint charts/openmetadata --values charts/openmetadata/values.yaml` — 0 failures
- [x] `helm lint` with `pipelineServiceClientConfig.type=k8s` and `rbac.enabled=true` — 0 failures
- [x] `ct lint --all --check-version-increment=false` — both charts pass
- [x] `helm template --dry-run --debug` — clean render
- [x] Python strict YAML duplicate-key parser — 5 documents, 0 duplicate keys
- [x] **Go `gopkg.in/yaml.v2` with `SetStrict(true)`** (exact library used by Flux helm-controller) — bug reproduced on `main`, clean pass on fix branch
- [x] `nameOverride` edge case — label correctly reflects override value
- [x] Default airflow pipeline type — `k8s-pipeline-rbac.yaml` not rendered (no regression)
- [x] `rbac.enabled=false` — template correctly suppressed