### PR TITLE
fix: add namespace support for K8sPipelineClient

### DIFF
--- a/charts/openmetadata/templates/secrets.yaml
+++ b/charts/openmetadata/templates/secrets.yaml
@@ -97,7 +97,7 @@ data:
   # Kubernetes Jobs configuration
   {{- with .k8s }}
   PIPELINE_SERVICE_CLIENT_CLASS_NAME: {{ .className | quote | b64enc }}
-  K8S_NAMESPACE: {{ $.Release.Namespace | quote | b64enc }}
+  K8S_NAMESPACE: {{ coalesce (.namespace | trim) $.Release.Namespace | quote | b64enc }}
   K8S_INGESTION_IMAGE: {{ .ingestionImage | quote | b64enc }}
   K8S_IMAGE_PULL_POLICY: {{ .imagePullPolicy | quote | b64enc }}
   K8S_IMAGE_PULL_SECRETS: {{ .imagePullSecrets | quote | b64enc }}

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -281,6 +281,9 @@
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
+                    "namespace": {
+                      "type": "string"
+                    },
                     "className": {
                       "type": "string"
                     },

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -112,6 +112,8 @@ openmetadata:
 
       # Kubernetes Jobs configuration (used when type: "k8s")
       k8s:
+        # Namespace for ingestion jobs (defaults to Helm release namespace if empty)
+        namespace: ""
         className: "org.openmetadata.service.clients.pipeline.k8s.K8sPipelineClient"
         # Container image for ingestion jobs
         ingestionImage: "docker.getcollate.io/openmetadata/ingestion-base:latest"


### PR DESCRIPTION
## Summary

Fixes #465

The `namespace` property was missing from `values.schema.json` under `pipelineServiceClientConfig.k8s`, causing Helm to reject it with:
> `additional properties 'namespace' not allowed`

There was also a second bug: `secrets.yaml` hardcoded `$.Release.Namespace` and ignored the user-supplied value entirely, so even if the schema had allowed it, the custom namespace would never have been applied.

### Changes

- **`values.schema.json`** — Add `namespace` as a `string` property to `pipelineServiceClientConfig.k8s` (schema had `additionalProperties: false`)
- **`secrets.yaml`** — Replace hardcoded `$.Release.Namespace` with `coalesce (.namespace | trim) $.Release.Namespace` — uses user-supplied value if set, falls back to release namespace otherwise
- **`values.yaml`** — Add `namespace: ""` as the documented default (empty = use release namespace)
- **`.gitignore`** — Exclude local IDE/AI tooling files (`.cursor/`, `.claude/`, `CLAUDE.md`, `openmemory.md`)
- **Version bump** — `1.12.1` → `1.12.2` across all version-bearing files per immutability requirement

### Backward Compatibility

Fully backward compatible. Users not setting `namespace` get identical behaviour to before — the Helm release namespace is used.

## Test plan

- [ ] `helm template` with `k8s.namespace: my-namespace` renders `K8S_NAMESPACE` as the custom value
- [ ] `helm template` with `namespace: ""` falls back to the Helm release namespace
- [ ] Whitespace-only `namespace: " "` is trimmed and falls back to release namespace
- [ ] Airflow type (`type: airflow`) renders without regression
- [ ] `helm lint` passes on both `openmetadata` and `deps` charts
- [ ] `K8S_NAMESPACE` env var verified against upstream server source (`conf/openmetadata.yaml:559`, `K8sPipelineClientConfig.java`, `K8sPipelineClient.java`)