### PR TITLE
fix: add imagePullSecrets support to omjob-operator deployment

### DIFF
--- a/charts/openmetadata/templates/omjob-operator-deployment.yaml
+++ b/charts/openmetadata/templates/omjob-operator-deployment.yaml
@@ -19,6 +19,10 @@ spec:
         {{- include "OpenMetadata.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: omjob-operator
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "OpenMetadata.fullname" . }}-omjob-operator
       containers:
       - name: operator


### PR DESCRIPTION
For the PR #477 comment:                                                                                                                 
                                                                                                                                           
This PR adds imagePullSecrets support to the omjob-operator deployment, which was the only deployment template missing it.             
                                                                                                                                           
The fix follows the same pattern already used by deployment.yaml, cron-reindex.yaml, and cron-deploy-pipelines.yaml — referencing the global .Values.imagePullSecrets. When imagePullSecrets is not configured (default), the block is simply omitted, so there is no impact on existing users.                                                                                                                         
                                                                                                                                         
  Testing done:                          
  - helm lint and ct lint --all pass
  - Template renders correctly with 0, 1, 2, and 3 imagePullSecrets
  - Verified omjob-operator deployment is not rendered when omjobOperator.enabled=false (default)                                          
  - Tested with the Datree CI test values overlay                                                                                          
  - Confirmed all other deployments/cronjobs render identical imagePullSecrets for consistency