### PR TITLE
fix: give OMJob operator its own selector labels

### DIFF
--- a/charts/openmetadata/templates/omjob-operator-deployment.yaml
+++ b/charts/openmetadata/templates/omjob-operator-deployment.yaml
@@ -11,12 +11,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "OpenMetadata.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: omjob-operator
+      app.kubernetes.io/name: {{ include "OpenMetadata.name" . }}-omjob-operator
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        {{- include "OpenMetadata.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/name: {{ include "OpenMetadata.name" . }}-omjob-operator
+        app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: omjob-operator
     spec:
       serviceAccountName: {{ include "OpenMetadata.fullname" . }}-omjob-operator


### PR DESCRIPTION
Fixes #482

The operator deployment uses OpenMetadata.selectorLabels which gives it the same app.kubernetes.io/name and app.kubernetes.io/instance labels as the server. Since the server Service also selects on those labels, it matches both server and operator pods.

The operator is a separate application - it should have its own name label. This PR changes the operator pod template and selector to use app.kubernetes.io/name: openmetadata-omjob-operator instead of inheriting the shared openmetadata name. It keeps the same release instance label and component label for Helm ownership tracking.

Only the operator deployment template is modified. The server deployment, service, and helpers are untouched.