### PR TITLE
Add Istio support to OpenMetadata chart

### DIFF
--- a/charts/openmetadata/README.md
+++ b/charts/openmetadata/README.md
@@ -305,6 +305,29 @@ You can enable `gateway` alongside `ingress` during migration. Configure hostnam
 | gateway.parentRefs[0].sectionName | string | `nil` |
 | gateway.parentRefs[0].port | int | `nil` |
 | gateway.rules | list | `[]` |
+| istio.annotations | object | `{}` |
+| istio.destinationRule.annotations | object | `{}` |
+| istio.destinationRule.enabled | bool | `false` |
+| istio.destinationRule.exportTo | list | `[]` |
+| istio.destinationRule.host | string | `""` |
+| istio.destinationRule.labels | object | `{}` |
+| istio.destinationRule.name | string | `""` |
+| istio.destinationRule.subsets | list | `[]` |
+| istio.destinationRule.trafficPolicy | object | `{}` |
+| istio.enabled | bool | `false` |
+| istio.gateway.annotations | object | `{}` |
+| istio.gateway.create | bool | `true` |
+| istio.gateway.labels | object | `{}` |
+| istio.gateway.name | string | `""` |
+| istio.gateway.selector | object | `{"istio":"ingressgateway"}` |
+| istio.gateway.servers | list | `[{"hosts":["open-metadata.local"],"port":{"name":"http","number":80,"protocol":"HTTP"}}]` |
+| istio.labels | object | `{}` |
+| istio.virtualService.annotations | object | `{}` |
+| istio.virtualService.gateways | list | `[]` |
+| istio.virtualService.hosts | list | `["open-metadata.local"]` |
+| istio.virtualService.http | list | `[]` |
+| istio.virtualService.labels | object | `{}` |
+| istio.virtualService.name | string | `""` |
 | ingress.annotations | object | `{}` |
 | ingress.className | string | `""` |
 | ingress.enabled | bool | `false` |
@@ -366,6 +389,12 @@ You can enable `gateway` alongside `ingress` during migration. Configure hostnam
 | openmetadata.config.reindexConfig.enabled | bool | `true` |
 
 ---
+
+### Istio Exposure
+
+Set `istio.enabled=true` to render Istio `Gateway` and `VirtualService` resources for OpenMetadata. The default VirtualService route forwards only to service port `8585`; the admin port `8586` remains internal for health checks and metrics.
+
+When `istio.gateway.create=false`, bind the generated VirtualService to an existing gateway by setting `istio.virtualService.gateways`. `istio.destinationRule.enabled=true` optionally adds a `DestinationRule` for mesh traffic policy/subset configuration.
 
 ## 🚨 BREAKING CHANGES
 

--- a/charts/openmetadata/templates/NOTES.txt
+++ b/charts/openmetadata/templates/NOTES.txt
@@ -1,5 +1,5 @@
 1. Get the application URL by running these commands:
-{{- $hasExternal := or .Values.ingress.enabled (or .Values.gateway.enabled .Values.route.enabled) }}
+{{- $hasExternal := or .Values.ingress.enabled (or .Values.gateway.enabled (or .Values.route.enabled .Values.istio.enabled)) }}
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
@@ -22,6 +22,16 @@
 {{- else }}
   OpenShift Route has been created without an explicit host. Run:
   kubectl get route {{ include "OpenMetadata.fullname" . }} -n {{ .Release.Namespace }} -o jsonpath='{.spec.host}'
+{{- end }}
+{{- end }}
+{{- if .Values.istio.enabled }}
+{{- if .Values.istio.virtualService.hosts }}
+  Istio VirtualService host(s):
+{{- range .Values.istio.virtualService.hosts }}
+  {{ . }}
+{{- end }}
+{{- else }}
+  Istio VirtualService has been created. Inspect `istio.virtualService.hosts` and the bound Istio Gateway listeners to determine the external hostname.
 {{- end }}
 {{- end }}
 {{- if and (not $hasExternal) (contains "NodePort" .Values.service.type) }}

--- a/charts/openmetadata/templates/_helpers.tpl
+++ b/charts/openmetadata/templates/_helpers.tpl
@@ -65,6 +65,36 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Resolve the Istio API version available in the target cluster.
+*/}}
+{{- define "OpenMetadata.istio.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "networking.istio.io/v1" -}}
+networking.istio.io/v1
+{{- else if .Capabilities.APIVersions.Has "networking.istio.io/v1beta1" -}}
+networking.istio.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "networking.istio.io/v1alpha3" -}}
+networking.istio.io/v1alpha3
+{{- else -}}
+{{- fail "istio.enabled is true but none of networking.istio.io/v1, networking.istio.io/v1beta1, or networking.istio.io/v1alpha3 APIs are available in the target cluster" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Istio resource names.
+*/}}
+{{- define "OpenMetadata.istio.gatewayName" -}}
+{{- default (include "OpenMetadata.fullname" .) .Values.istio.gateway.name -}}
+{{- end }}
+
+{{- define "OpenMetadata.istio.virtualServiceName" -}}
+{{- default (include "OpenMetadata.fullname" .) .Values.istio.virtualService.name -}}
+{{- end }}
+
+{{- define "OpenMetadata.istio.destinationRuleName" -}}
+{{- default (include "OpenMetadata.fullname" .) .Values.istio.destinationRule.name -}}
+{{- end }}
+
+{{/*
 Quoted Array of strings with base64 encoding
 */}}
 {{- define "OpenMetadata.commaJoinedQuotedEncodedList" }}

--- a/charts/openmetadata/templates/istio-destinationrule.yaml
+++ b/charts/openmetadata/templates/istio-destinationrule.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.istio.enabled .Values.istio.destinationRule.enabled }}
+apiVersion: {{ include "OpenMetadata.istio.apiVersion" . }}
+kind: DestinationRule
+metadata:
+  name: {{ include "OpenMetadata.istio.destinationRuleName" . }}
+  labels:
+    {{- include "OpenMetadata.labels" . | nindent 4 }}
+    {{- with .Values.istio.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.istio.destinationRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.istio.annotations .Values.istio.destinationRule.annotations }}
+  annotations:
+    {{- with .Values.istio.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.istio.destinationRule.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  host: {{ default (include "OpenMetadata.fullname" .) .Values.istio.destinationRule.host | quote }}
+  {{- with .Values.istio.destinationRule.trafficPolicy }}
+  trafficPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.istio.destinationRule.subsets }}
+  subsets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.istio.destinationRule.exportTo }}
+  exportTo:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/openmetadata/templates/istio-gateway.yaml
+++ b/charts/openmetadata/templates/istio-gateway.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.istio.enabled .Values.istio.gateway.create }}
+apiVersion: {{ include "OpenMetadata.istio.apiVersion" . }}
+kind: Gateway
+metadata:
+  name: {{ include "OpenMetadata.istio.gatewayName" . }}
+  labels:
+    {{- include "OpenMetadata.labels" . | nindent 4 }}
+    {{- with .Values.istio.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.istio.gateway.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.istio.annotations .Values.istio.gateway.annotations }}
+  annotations:
+    {{- with .Values.istio.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.istio.gateway.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  selector:
+    {{- toYaml .Values.istio.gateway.selector | nindent 4 }}
+  servers:
+    {{- toYaml .Values.istio.gateway.servers | nindent 4 }}
+{{- end }}

--- a/charts/openmetadata/templates/istio-virtualservice.yaml
+++ b/charts/openmetadata/templates/istio-virtualservice.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.istio.enabled }}
+{{- $fullName := include "OpenMetadata.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: {{ include "OpenMetadata.istio.apiVersion" . }}
+kind: VirtualService
+metadata:
+  name: {{ include "OpenMetadata.istio.virtualServiceName" . }}
+  labels:
+    {{- include "OpenMetadata.labels" . | nindent 4 }}
+    {{- with .Values.istio.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.istio.virtualService.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.istio.annotations .Values.istio.virtualService.annotations }}
+  annotations:
+    {{- with .Values.istio.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.istio.virtualService.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  hosts:
+    {{- range .Values.istio.virtualService.hosts }}
+    - {{ . | quote }}
+    {{- end }}
+  gateways:
+    {{- if .Values.istio.virtualService.gateways }}
+    {{- range .Values.istio.virtualService.gateways }}
+    - {{ . | quote }}
+    {{- end }}
+    {{- else }}
+    - {{ include "OpenMetadata.istio.gatewayName" . | quote }}
+    {{- end }}
+  http:
+    {{- if .Values.istio.virtualService.http }}
+    {{- toYaml .Values.istio.virtualService.http | nindent 4 }}
+    {{- else }}
+    - match:
+        - uri:
+            prefix: /
+      route:
+        - destination:
+            host: {{ $fullName | quote }}
+            port:
+              number: {{ $svcPort }}
+    {{- end }}
+{{- end }}

--- a/charts/openmetadata/templates/validate-values.tpl
+++ b/charts/openmetadata/templates/validate-values.tpl
@@ -5,3 +5,24 @@
 {{- if not .Values.openmetadata.config.openmetadata }}
 {{- include "error-message" "Global key has been replaced by openmetadata.config. Please refer docs for the further explaination." }}
 {{- end }}
+
+{{- $externalExposureModes := 0 }}
+{{- if .Values.ingress.enabled }}
+  {{- $externalExposureModes = add1 $externalExposureModes }}
+{{- end }}
+{{- if .Values.gateway.enabled }}
+  {{- $externalExposureModes = add1 $externalExposureModes }}
+{{- end }}
+{{- if .Values.route.enabled }}
+  {{- $externalExposureModes = add1 $externalExposureModes }}
+{{- end }}
+{{- if .Values.istio.enabled }}
+  {{- $externalExposureModes = add1 $externalExposureModes }}
+{{- end }}
+{{- if gt $externalExposureModes 1 }}
+{{- include "error-message" "Only one of ingress.enabled, gateway.enabled, route.enabled, or istio.enabled can be true." }}
+{{- end }}
+
+{{- if and .Values.istio.enabled (not .Values.istio.gateway.create) (empty .Values.istio.virtualService.gateways) }}
+{{- include "error-message" "istio.virtualService.gateways must be set when istio.enabled=true and istio.gateway.create=false." }}
+{{- end }}

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -1661,6 +1661,117 @@
         }
       }
     },
+    "istio": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "labels": {
+          "type": "object"
+        },
+        "gateway": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object"
+            },
+            "labels": {
+              "type": "object"
+            },
+            "selector": {
+              "type": "object"
+            },
+            "servers": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "virtualService": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object"
+            },
+            "labels": {
+              "type": "object"
+            },
+            "hosts": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "gateways": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "http": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "destinationRule": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object"
+            },
+            "labels": {
+              "type": "object"
+            },
+            "host": {
+              "type": "string"
+            },
+            "trafficPolicy": {
+              "type": "object"
+            },
+            "subsets": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "exportTo": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
     "livenessProbe": {
       "type": "object",
       "properties": {

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -576,6 +576,61 @@ route:
     #   None     — drop HTTP traffic
     insecureEdgeTerminationPolicy: Redirect
 
+# Istio ingress resources — use instead of ingress/gateway/route when your cluster
+# is fronted by an Istio ingress gateway.
+istio:
+  enabled: false
+  annotations: {}
+  labels: {}
+  gateway:
+    # Create an Istio Gateway resource. Set to false when binding the VirtualService
+    # to a pre-existing gateway and provide the gateway name(s) in
+    # istio.virtualService.gateways.
+    create: true
+    name: ""
+    annotations: {}
+    labels: {}
+    selector:
+      istio: ingressgateway
+    servers:
+      - port:
+          number: 80
+          name: http
+          protocol: HTTP
+        hosts:
+          - open-metadata.local
+  virtualService:
+    name: ""
+    annotations: {}
+    labels: {}
+    hosts:
+      - open-metadata.local
+    # When empty and istio.gateway.create=true, the chart binds the VirtualService
+    # to the generated Gateway. When istio.gateway.create=false, set this explicitly.
+    gateways: []
+    # If omitted, the chart creates a default route matching "/" and forwarding
+    # traffic only to the application port (8585). The admin port (8586) remains
+    # internal-only and should not be exposed externally.
+    http: []
+      # - match:
+      #     - uri:
+      #         prefix: /
+      #   route:
+      #     - destination:
+      #         host: openmetadata
+      #         port:
+      #           number: 8585
+  destinationRule:
+    enabled: false
+    name: ""
+    annotations: {}
+    labels: {}
+    # Defaults to the OpenMetadata service when empty.
+    host: ""
+    trafficPolicy: {}
+    subsets: []
+    exportTo: []
+
 extraEnvs: []
 # - name: MY_ENVIRONMENT_VAR
 #   value: the_value_goes_here


### PR DESCRIPTION
## Summary
- add Istio Gateway, VirtualService, and optional DestinationRule templates to the OpenMetadata chart
- add Istio values, schema, validation, and NOTES/README updates
- keep the admin port 8586 internal while routing external traffic to 8585 by default

## Testing
- helm lint charts/openmetadata
- helm template om charts/openmetadata --set istio.enabled=true --api-versions networking.istio.io/v1
- helm template om charts/openmetadata --set istio.enabled=true --set ingress.enabled=true --api-versions networking.istio.io/v1
- helm template om charts/openmetadata --set istio.enabled=true --set istio.gateway.create=false --api-versions networking.istio.io/v1