### PR TITLE
docs(deps): document Airflow logs PVC ReadWriteMany requirement

### DIFF
--- a/charts/deps/README.md
+++ b/charts/deps/README.md
@@ -68,9 +68,17 @@ The default configuration uses KubernetesExecutor, which is recommended for prod
    ```
    Update `airflow.webserverSecretKey` in your values file with the generated key.
 
-2. **Configure RWX Storage**: KubernetesExecutor requires ReadWriteMany (RWX) storage for DAGs:
-   - Update `airflow.dags.persistence.storageClassName` to a storage class that supports RWX (e.g., `efs-sc` on AWS, `azurefile` on Azure, `nfs-client` on GKE)
-   - Most cloud providers support RWX storage classes
+2. **Configure RWX Storage**: KubernetesExecutor requires ReadWriteMany (RWX) storage for DAGs and logs:
+   - Update `airflow.dags.persistence.storageClassName` to a storage class that supports RWX (e.g., `efs-sc` on AWS, `azurefile` on Azure, `filestore-rwx` on GKE)
+   - **Important**: The upstream Airflow chart (v1.18.0) hardcodes `ReadWriteMany` on the logs PVC. If your storage class only supports `ReadWriteOnce` (e.g., GKE Autopilot's `standard-rwo`), you must either use an RWX-capable storage class for `airflow.logs.persistence.storageClassName` or disable logs persistence (`airflow.logs.persistence.enabled: false`)
+   - Most cloud providers offer RWX storage classes (see table below)
+
+   | Cloud Provider | RWX Storage Class | Notes |
+   |---|---|---|
+   | AWS | `efs-sc` | Requires EFS CSI driver |
+   | Azure | `azurefile` | Built-in |
+   | GKE | `filestore-rwx` | Requires Filestore CSI driver |
+   | GKE Autopilot | N/A | Use `airflow.logs.persistence.enabled: false` as a workaround |
 
 3. **Adjust Worker Replicas**: Set `airflow.workers.replicas` based on your workload (default is 2)
 
@@ -86,6 +94,9 @@ airflow:
   dags:
     persistence:
       storageClassName: "efs-sc"  # Or your RWX storage class
+  logs:
+    persistence:
+      storageClassName: "efs-sc"  # Must be RWX-capable (hardcoded by upstream Airflow chart)
 mysql:
   auth:
     rootPassword: "<strong-password>"

--- a/charts/deps/values.yaml
+++ b/charts/deps/values.yaml
@@ -144,6 +144,12 @@ airflow:
       storageClassName: ""
       size: 1Gi
   # Logs persistence configuration
+  # WARNING: The upstream Airflow chart (v1.18.0) hardcodes the logs PVC access mode
+  # to ReadWriteMany (RWX). If your cluster/storage class only supports ReadWriteOnce
+  # (e.g., GKE Autopilot with standard-rwo), you must either:
+  #   1. Set storageClassName to an RWX-capable class (e.g., "filestore-rwx" on GKE,
+  #      "efs-sc" on AWS, "azurefile" on Azure)
+  #   2. Disable logs persistence (enabled: false) to use emptyDir instead
   logs:
     persistence:
       enabled: true


### PR DESCRIPTION
## Summary

Fixes #468

The upstream Apache Airflow Helm chart (v1.18.0) hardcodes `ReadWriteMany` as the access mode on the logs PersistentVolumeClaim ([`logs-persistent-volume-claim.yaml:41`](https://github.com/apache/airflow/blob/helm-chart/1.18.0/chart/templates/logs-persistent-volume-claim.yaml#L41)). This causes PVC provisioning failures on clusters whose default storage class only supports `ReadWriteOnce`, such as GKE Autopilot with `standard-rwo`:

```
VolumeCapabilities is invalid: specified multi writer with mount access type
```

Unlike the DAGs PVC (which uses a configurable `dags.persistence.accessMode`), the logs PVC access mode is not configurable — even in the latest upstream chart version (v1.20.0).

### Changes

- **`charts/deps/values.yaml`**: Added a `WARNING` comment above the `airflow.logs.persistence` section explaining the RWX requirement and two workarounds (use an RWX storage class, or disable logs persistence)
- **`charts/deps/README.md`**:
  - Expanded the "Configure RWX Storage" guidance to cover both DAGs and logs
  - Added a cloud provider RWX storage class reference table (AWS, Azure, GKE, GKE Autopilot)
  - Updated example production values to include `logs.persistence.storageClassName`

### Root Cause Analysis

| PVC | Access Mode | Configurable? | Status |
|---|---|---|---|
| DAGs | `ReadWriteOnce` (default) | Yes (`dags.persistence.accessMode`) | Works |
| Logs | `ReadWriteMany` (hardcoded) | **No** | **Fails on RWO-only storage** |
| OpenSearch | `ReadWriteOnce` | Yes | Works |

### Workarounds for affected users

1. Use an RWX-capable storage class:
   ```yaml
   airflow:
     logs:
       persistence:
         storageClassName: "filestore-rwx"  # GKE example
   ```

2. Disable logs persistence:
   ```yaml
   airflow:
     logs:
       persistence:
         enabled: false
   ```

## Test plan

- [ ] Verify `helm template --dry-run` renders cleanly with default values
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm workarounds resolve the issue on GKE Autopilot