### PR TITLE
docs(openmetadata): warn about Elasticsearch searchType index update issue on restarts

### DIFF
--- a/charts/openmetadata/README.md
+++ b/charts/openmetadata/README.md
@@ -158,7 +158,7 @@ helm install openmetadata open-metadata/openmetadata --values <<path-to-values-f
 | openmetadata.config.elasticsearch.keepAliveTimeoutSecs | int | `600` | ELASTICSEARCH_KEEP_ALIVE_TIMEOUT_SECS |
 | openmetadata.config.elasticsearch.payLoadSize | int | 10485760 | ELASTICSEARCH_PAYLOAD_BYTES_SIZE |
 | openmetadata.config.elasticsearch.port | int | 9200 | ELASTICSEARCH_PORT |
-| openmetadata.config.elasticsearch.searchType | string | `opensearch` | SEARCH_TYPE |
+| openmetadata.config.elasticsearch.searchType | string | `opensearch` | SEARCH_TYPE. **Note:** `elasticsearch` has a [known issue](https://github.com/open-metadata/openmetadata-helm-charts/issues/451) with index updates on pod restarts. Use `opensearch` (default) when possible. |
 | openmetadata.config.elasticsearch.scheme | string | `http` | ELASTICSEARCH_SCHEME |
 | openmetadata.config.elasticsearch.clusterAlias | string | `Empty String` | ELASTICSEARCH_CLUSTER_ALIAS |
 | openmetadata.config.elasticsearch.searchIndexMappingLanguage | string | `EN`| ELASTICSEARCH_INDEX_MAPPING_LANG |
@@ -590,3 +590,18 @@ kubectl get serviceaccounts,roles,rolebindings \
   -n openmetadata-pipelines \
   -l app.kubernetes.io/component=ingestion
 ```
+
+### Troubleshooting Elasticsearch Index Updates
+
+When using `searchType: elasticsearch` with Elasticsearch 8.x, the `run-db-migrations` init container may fail on pod restarts with:
+
+```
+JsonpMappingException: Error deserializing PutMappingRequest: Unknown field 'settings'
+```
+
+This is a known application-level issue ([#451](https://github.com/open-metadata/openmetadata-helm-charts/issues/451)) where the migration code sends index `settings` in a `PutMappingRequest`, which Elasticsearch rejects. It only occurs when updating existing indices — creating from scratch works fine.
+
+**Workarounds:**
+1. **Switch to OpenSearch** (recommended): Set `searchType: opensearch` and use OpenSearch instead of Elasticsearch. This is the default and tested configuration.
+2. **Delete indices before restart**: Remove Elasticsearch indices so the migration creates them fresh instead of updating.
+3. **Use the reindex CronJob**: Enable `openmetadata.config.reindexConfig.enabled` to periodically rebuild indices rather than relying on migration-time updates.

--- a/charts/openmetadata/templates/NOTES.txt
+++ b/charts/openmetadata/templates/NOTES.txt
@@ -20,3 +20,11 @@
   echo "Visit http://127.0.0.1:8585 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8585:$CONTAINER_PORT
 {{- end }}
+{{- if eq .Values.openmetadata.config.elasticsearch.searchType "elasticsearch" }}
+
+⚠️  WARNING: You are using searchType "elasticsearch". There is a known issue where
+the run-db-migrations init container fails on pod restarts when updating existing
+Elasticsearch indices (PutMappingRequest rejects the "settings" field).
+Consider using searchType "opensearch" (default) to avoid this issue.
+See: https://github.com/open-metadata/openmetadata-helm-charts/issues/451
+{{- end }}

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -1069,7 +1069,8 @@
                 },
                 "searchType": {
                   "type": "string",
-                  "default": "elasticsearch",
+                  "default": "opensearch",
+                  "description": "Search backend type. 'opensearch' is recommended. 'elasticsearch' has a known issue with index updates on pod restarts (see issue #451).",
                   "enum": [
                     "elasticsearch",
                     "opensearch"

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -34,6 +34,13 @@ openmetadata:
     elasticsearch:
       enabled: true
       host: opensearch
+      # Supported values: "opensearch" (default, recommended) or "elasticsearch"
+      # NOTE: Using "elasticsearch" with Elasticsearch 8.x has a known issue where
+      # the run-db-migrations init container fails on pod restarts when updating
+      # existing search indices (PutMappingRequest rejects "settings" field).
+      # Creating indices from scratch works fine. If you must use Elasticsearch,
+      # consider deleting indices before restarting or switching to OpenSearch.
+      # See: https://github.com/open-metadata/openmetadata-helm-charts/issues/451
       searchType: opensearch
       port: 9200
       scheme: http


### PR DESCRIPTION
## Summary

Ref #451

When using `searchType: elasticsearch` with Elasticsearch 8.x, the `run-db-migrations` init container fails on pod restarts with:

```
JsonpMappingException: Error deserializing PutMappingRequest: Unknown field 'settings'
```

**Root cause:** This is an application-level bug in `ElasticSearchIndexManager.updateIndex()` which sends the full index definition (including `settings`) to the Elasticsearch `PutMapping` API. The `PutMapping` endpoint only accepts `mappings`, not `settings`. This only occurs when updating existing indices — creating from scratch works fine. The default `opensearch` searchType is unaffected.

Since the fix requires changes to the OpenMetadata server (not the Helm chart), this PR adds documentation and warnings to help users avoid or work around the issue.

### Changes

- **`values.yaml`**: Added warning comment above `searchType` explaining the limitation
- **`values.schema.json`**: Added `description` with warning; fixed `default` from `"elasticsearch"` to `"opensearch"` (was inconsistent with actual `values.yaml` default)
- **`README.md`**: Added inline note in the values table for `searchType`; added "Troubleshooting Elasticsearch Index Updates" section with 3 workarounds
- **`NOTES.txt`**: Added conditional warning shown at `helm install`/`upgrade` time when `searchType: elasticsearch` is detected

### Workarounds documented

1. **Switch to OpenSearch** (recommended) — use the default `searchType: opensearch`
2. **Delete indices before restart** — forces fresh creation instead of update
3. **Use the reindex CronJob** — enable `reindexConfig.enabled` for periodic rebuilds

## Test plan

- [x] `helm lint` passes with default values (`opensearch`)
- [x] `helm lint` passes with `searchType: elasticsearch`
- [x] `helm template` renders cleanly for both searchType values
- [x] NOTES.txt warning only appears when `searchType: elasticsearch`
- [ ] Verify README renders correctly on GitHub