### PR TITLE
openmetadata- Fix excessive RBAC permissions on pods/log #498

### DIFF
--- a/charts/openmetadata/templates/k8s-pipeline-rbac.yaml
+++ b/charts/openmetadata/templates/k8s-pipeline-rbac.yaml
@@ -26,8 +26,12 @@ metadata:
 rules:
 # Pod management for pipeline jobs and diagnostics
 - apiGroups: [""]
-  resources: ["pods", "pods/log"]
+  resources: ["pods"]
   verbs: ["get", "list", "create", "update", "patch", "delete"]
+# Pod logs with read-only access for diagnostics
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get", "list", "watch"]
 # ConfigMaps for pipeline configuration
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -74,8 +78,12 @@ metadata:
 rules:
 # Pod management for pipeline jobs and diagnostics
 - apiGroups: [""]
-  resources: ["pods", "pods/log"]
+  resources: ["pods"]
   verbs: ["get", "list", "create", "update", "patch", "delete"]
+# Pod logs with read-only access for diagnostics
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get", "list", "watch"]
 # ConfigMaps for pipeline configuration
 - apiGroups: [""]
   resources: ["configmaps"]


### PR DESCRIPTION
### What this PR does / why we need it :
<!-- Explain what you have done & tag your assigned issue !-->
<!-- Which issue this PR fixes (if applicable) !-->
Fixes #498 
This PR updates the RBAC configuration related to pods/log.

- Restricts permissions on pods/log to read-only verbs (get, list, watch)
- Removes unnecessary write verbs (create, update, patch, delete) which are not applicable to this subresource
- Improves security by aligning with the principle of least privilege
- Adds a comment to document the intent of this rule

This change also ensures compatibility with environments enforcing stricter Kubernetes RBAC policies, where the previous configuration prevents deployment.


#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- @akash-jain-10 @tutte @dhruvinmaniar123 !-->