### PR TITLE
Fix #27399: add imagePullSecrets to OMJob operator and ingestion ServiceAccounts

### DIFF
--- a/charts/openmetadata/templates/k8s-pipeline-rbac.yaml
+++ b/charts/openmetadata/templates/k8s-pipeline-rbac.yaml
@@ -1,5 +1,6 @@
 {{- if and .Values.openmetadata.config.pipelineServiceClientConfig.enabled (eq .Values.openmetadata.config.pipelineServiceClientConfig.type "k8s") }}
 {{- $namespace := .Release.Namespace }}
+{{- $omjobImagePullSecrets := .Values.omjobOperator.imagePullSecrets | default .Values.imagePullSecrets }}
 {{- if .Values.openmetadata.config.pipelineServiceClientConfig.k8s.rbac.enabled }}
 ---
 apiVersion: v1
@@ -14,6 +15,10 @@ metadata:
     {{- if .Values.serviceAccount.annotations }}
     {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
     {{- end }}
+{{- with $omjobImagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/openmetadata/templates/omjob-operator-deployment.yaml
+++ b/charts/openmetadata/templates/omjob-operator-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.omjobOperator.enabled }}
+{{- $omjobImagePullSecrets := .Values.omjobOperator.imagePullSecrets | default .Values.imagePullSecrets }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,7 +20,7 @@ spec:
         {{- include "OpenMetadata.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: omjob-operator
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with $omjobImagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/openmetadata/templates/omjob-operator-rbac.yaml
+++ b/charts/openmetadata/templates/omjob-operator-rbac.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.omjobOperator.enabled }}
+{{- $omjobImagePullSecrets := .Values.omjobOperator.imagePullSecrets | default .Values.imagePullSecrets }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -8,6 +9,10 @@ metadata:
   labels:
     {{- include "OpenMetadata.labels" . | nindent 4 }}
     app.kubernetes.io/component: omjob-operator
+{{- with $omjobImagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -2041,6 +2041,19 @@
         "enabled": {
           "type": "boolean"
         },
+        "imagePullSecrets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": ["name"]
+          }
+        },
         "image": {
           "type": "object",
           "additionalProperties": false,

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -759,6 +759,9 @@ hpa:
 omjobOperator:
   enabled: false  # Set to true to install OMJob CRD and operator
 
+  # Image pull secrets for operator/ingestion service accounts and operator pod
+  imagePullSecrets: []
+
   # Image configuration
   image:
     repository: docker.getcollate.io/openmetadata/omjob-operator


### PR DESCRIPTION
## Summary
- add omjobOperator.imagePullSecrets to chart values and schema
- use omjobOperator.imagePullSecrets (fallback to global imagePullSecrets) for OMJob operator deployment pod
- attach image pull secrets to both ServiceAccounts created by the chart:
  - OMJob operator ServiceAccount
  - ingestion ServiceAccount for k8s pipeline RBAC

## Notes
- this keeps backward compatibility by falling back to global imagePullSecrets when omjobOperator.imagePullSecrets is not set
- local chart render validation could not be executed in this environment because helm is not installed

Fixes #27399 (https://github.com/open-metadata/OpenMetadata/issues/27399)