### PR TITLE
fix: use Helm fullname helper for server-pipeline-manager Role/RoleBinding

### DIFF
--- a/charts/openmetadata/templates/k8s-pipeline-rbac.yaml
+++ b/charts/openmetadata/templates/k8s-pipeline-rbac.yaml
@@ -66,7 +66,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: openmetadata-server-pipeline-manager
+  name: {{ include "OpenMetadata.fullname" . }}-server-pipeline-manager
   namespace: {{ $namespace }}
   labels:
     app.kubernetes.io/component: server
@@ -111,7 +111,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: openmetadata-server-pipeline-manager
+  name: {{ include "OpenMetadata.fullname" . }}-server-pipeline-manager
   namespace: {{ $namespace }}
   labels:
     app.kubernetes.io/component: server
@@ -122,7 +122,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: openmetadata-server-pipeline-manager
+  name: {{ include "OpenMetadata.fullname" . }}-server-pipeline-manager
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR fixes the hardcoded resource names reported in open-metadata/OpenMetadata#27575.

Right now, the Role and RoleBinding for the server pipeline manager are hardcoded to `openmetadata-server-pipeline-manager`. This is a bit problematic because it ignores `fullnameOverride` and `nameOverride` configurations, which can cause clashes if someone tries to deploy multiple Helm releases in the same namespace.

### What changed?
I swapped out the hardcoded strings for the dynamic `{{ include "OpenMetadata.fullname" . }}-server-pipeline-manager` template helper in three spots:
- The `metadata.name` for the Role 
- The `metadata.name` for the RoleBinding
- The `roleRef.name` string inside the RoleBinding so it continues to match the new dynamic Role name

### Testing
I've already verified this locally by running:
- `helm template` with default values (the resource names correctly inherit the parent release name now)
- `helm template` with an explicit `fullnameOverride`
- `helm lint`, which passes cleanly with no errors!

Let me know if I need to adjust anything!