### PR TITLE
fix: use OpenMetadata.fullname for pipeline manager RBAC resources

### DIFF
--- a/charts/openmetadata/templates/k8s-pipeline-rbac.yaml
+++ b/charts/openmetadata/templates/k8s-pipeline-rbac.yaml
@@ -66,7 +66,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: openmetadata-server-pipeline-manager
+  name: {{ include "OpenMetadata.fullname" . }}-server-pipeline-manager
   namespace: {{ $namespace }}
   labels:
     app.kubernetes.io/component: server
@@ -111,7 +111,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: openmetadata-server-pipeline-manager
+  name: {{ include "OpenMetadata.fullname" . }}-server-pipeline-manager
   namespace: {{ $namespace }}
   labels:
     app.kubernetes.io/component: server
@@ -122,7 +122,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: openmetadata-server-pipeline-manager
+  name: {{ include "OpenMetadata.fullname" . }}-server-pipeline-manager
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary
Fixes open-metadata/OpenMetadata#27575

This replaces the hardcoded `openmetadata-server-pipeline-manager` name used for the pipeline manager's RBAC resources with the standard `OpenMetadata.fullname` helper. This fixes namespace collisions in multi-release deployments and allows it to properly respect Helm overrides like `fullnameOverride`.

## Changes
Modified `charts/openmetadata/templates/k8s-pipeline-rbac.yaml` to use the dynamic `{{ include "OpenMetadata.fullname" . }}-server-pipeline-manager` naming format across:
- The `Role` metadata name
- The `RoleBinding` metadata name
- The `RoleBinding` roleRef name