### PR TITLE
openmetadata: support seccompProfile in K8s config

### DIFF
--- a/charts/openmetadata/Chart.yaml
+++ b/charts/openmetadata/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.12.6
+version: 1.12.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openmetadata/README.md
+++ b/charts/openmetadata/README.md
@@ -587,6 +587,7 @@ openmetadata:
 | `k8s.securityContext.fsGroup` | `1000` | Filesystem group for ingestion pods |
 | `k8s.securityContext.runAsNonRoot` | `true` | Force ingestion pods to run as non-root |
 | `k8s.securityContext.seccompProfile.type` | `unset` | Seccomp profile applied to ingestion pods/containers. Allowed values: `RuntimeDefault`, `Localhost`, `Unconfined`. Set to `RuntimeDefault` when running in namespaces enforcing the [restricted Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/) |
+| `k8s.securityContext.seccompProfile.localhostProfile` | `unset` | Path to a node-local seccomp profile (e.g. `profiles/audit.json`), relative to the kubelet's configured seccomp profile root. Required when `seccompProfile.type` is `Localhost` |
 
 ### RBAC and Security
 

--- a/charts/openmetadata/README.md
+++ b/charts/openmetadata/README.md
@@ -552,6 +552,11 @@ openmetadata:
           runAsGroup: 1000
           fsGroup: 1000
           runAsNonRoot: true
+          # Optional: required by namespaces enforcing the
+          # "restricted" Pod Security Standard. Allowed values for
+          # `type`: RuntimeDefault, Localhost, Unconfined.
+          # seccompProfile:
+          #   type: RuntimeDefault
         
         # Failure diagnostics
         enableFailureDiagnostics: true
@@ -577,6 +582,11 @@ openmetadata:
 | `k8s.successfulJobsHistoryLimit` | `3` | Keep last N successful jobs |
 | `k8s.failedJobsHistoryLimit` | `3` | Keep last N failed jobs |
 | `k8s.enableFailureDiagnostics` | `true` | Enable automatic failure analysis |
+| `k8s.securityContext.runAsUser` | `1000` | UID for ingestion pods/containers |
+| `k8s.securityContext.runAsGroup` | `1000` | GID for ingestion pods/containers |
+| `k8s.securityContext.fsGroup` | `1000` | Filesystem group for ingestion pods |
+| `k8s.securityContext.runAsNonRoot` | `true` | Force ingestion pods to run as non-root |
+| `k8s.securityContext.seccompProfile.type` | `unset` | Seccomp profile applied to ingestion pods/containers. Allowed values: `RuntimeDefault`, `Localhost`, `Unconfined`. Set to `RuntimeDefault` when running in namespaces enforcing the [restricted Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/) |
 
 ### RBAC and Security
 

--- a/charts/openmetadata/templates/secrets.yaml
+++ b/charts/openmetadata/templates/secrets.yaml
@@ -112,6 +112,9 @@ data:
   K8S_RUN_AS_GROUP: {{ .securityContext.runAsGroup | quote | b64enc }}
   K8S_FS_GROUP: {{ .securityContext.fsGroup | quote | b64enc }}
   K8S_RUN_AS_NON_ROOT: {{ .securityContext.runAsNonRoot | quote | b64enc }}
+  {{- with .securityContext.seccompProfile }}
+  K8S_SECCOMP_PROFILE_TYPE: {{ .type | quote | b64enc }}
+  {{- end }}
   K8S_LIMITS_CPU: {{ .resources.limits.cpu | quote | b64enc }}
   K8S_LIMITS_MEMORY: {{ .resources.limits.memory | quote | b64enc }}
   K8S_REQUESTS_CPU: {{ .resources.requests.cpu | quote | b64enc }}

--- a/charts/openmetadata/templates/secrets.yaml
+++ b/charts/openmetadata/templates/secrets.yaml
@@ -114,6 +114,9 @@ data:
   K8S_RUN_AS_NON_ROOT: {{ .securityContext.runAsNonRoot | quote | b64enc }}
   {{- with .securityContext.seccompProfile }}
   K8S_SECCOMP_PROFILE_TYPE: {{ .type | quote | b64enc }}
+  {{- if .localhostProfile }}
+  K8S_SECCOMP_LOCALHOST_PROFILE: {{ .localhostProfile | quote | b64enc }}
+  {{- end }}
   {{- end }}
   K8S_LIMITS_CPU: {{ .resources.limits.cpu | quote | b64enc }}
   K8S_LIMITS_MEMORY: {{ .resources.limits.memory | quote | b64enc }}

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -393,6 +393,10 @@
                                 "Unconfined"
                               ],
                               "description": "Seccomp profile type for ingestion pods/containers. Required by namespaces enforcing the restricted Pod Security Standard."
+                            },
+                            "localhostProfile": {
+                              "type": "string",
+                              "description": "Path to a node-local seccomp profile, relative to the kubelet's configured seccomp profile root (e.g. 'profiles/audit.json'). Required when type is 'Localhost'."
                             }
                           },
                           "required": [
@@ -1334,7 +1338,6 @@
                 "idleThreadTimeout": {
                   "type": "string"
                 }
-
               }
             },
             "secretsManager": {

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -380,6 +380,24 @@
                         },
                         "runAsNonRoot": {
                           "type": "boolean"
+                        },
+                        "seccompProfile": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "RuntimeDefault",
+                                "Localhost",
+                                "Unconfined"
+                              ],
+                              "description": "Seccomp profile type for ingestion pods/containers. Required by namespaces enforcing the restricted Pod Security Standard."
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ]
                         }
                       }
                     },

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -148,8 +148,15 @@ openmetadata:
           runAsGroup: 1000
           fsGroup: 1000
           runAsNonRoot: true
+          # Optional: required by namespaces enforcing the
+          # "restricted" Pod Security Standard. Allowed values for
+          # `type`: RuntimeDefault, Localhost, Unconfined.
+          # When type is Localhost, also set `localhostProfile`
+          # to the path of the profile on the node, relative to
+          # the kubelet's configured seccomp profile root.
           # seccompProfile:
           #   type: RuntimeDefault
+          #   # localhostProfile: profiles/audit.json
         # Resource limits and requests
         resources:
           limits:

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -148,6 +148,8 @@ openmetadata:
           runAsGroup: 1000
           fsGroup: 1000
           runAsNonRoot: true
+          # seccompProfile:
+          #   type: RuntimeDefault
         # Resource limits and requests
         resources:
           limits:


### PR DESCRIPTION
### What this PR does / why we need it :
This PR expands the configuration of the K8S pipeline client, adding the property `seccompProfileType` allowing the user to set it to one of `RuntimeDefault`, `Localhost` or Unconfined. This is needed when the pipeline is created in a namespace where the pod security standard is set to "restricted".

To go along with this PR I have also created a PR in the OpenMetaData repo implementing this functionality: [!27801](https://github.com/open-metadata/OpenMetadata/pull/27801)

Fixes open-metadata/OpenMetadata#28858

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] All new and existing tests passed.

#
### Reviewers
@akash-jain-10 @tutte @dhruvinmaniar123