### PR TITLE
Expose omjobOperator.podSecurityContext / securityContext

### DIFF
--- a/charts/openmetadata/templates/omjob-operator-deployment.yaml
+++ b/charts/openmetadata/templates/omjob-operator-deployment.yaml
@@ -24,8 +24,16 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "OpenMetadata.fullname" . }}-omjob-operator
+      {{- with .Values.omjobOperator.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: operator
+        {{- with .Values.omjobOperator.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         image: "{{ .Values.omjobOperator.image.repository }}:{{ .Values.omjobOperator.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.omjobOperator.image.pullPolicy }}
         env:

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -2126,6 +2126,12 @@
               "type": "boolean"
             }
           }
+        },
+        "podSecurityContext": {
+          "type": "object"
+        },
+        "securityContext": {
+          "type": "object"
         }
       }
     }

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -790,3 +790,26 @@ omjobOperator:
     # - "namespace1,namespace2" = watch specific namespaces (recommended)
     # - Leave empty for operator's own namespace only
     watchNamespaces: ""
+
+  # Pod-level securityContext for the operator pod. Empty by default for
+  # backwards compatibility. Required for clusters that enforce Pod
+  # Security Standards "restricted".
+  podSecurityContext: {}
+    # runAsNonRoot: true
+    # runAsUser: 1000
+    # runAsGroup: 1000
+    # seccompProfile:
+    #   type: RuntimeDefault
+
+  # Container-level securityContext for the operator container. Required
+  # for PSS Restricted; the operator image runs as user `omjob` (UID 1000).
+  securityContext: {}
+    # allowPrivilegeEscalation: false
+    # capabilities:
+    #   drop: [ALL]
+    # readOnlyRootFilesystem: false   # JVM operators may need writable root
+    # runAsNonRoot: true
+    # runAsUser: 1000
+    # runAsGroup: 1000
+    # seccompProfile:
+    #   type: RuntimeDefault


### PR DESCRIPTION
## Summary

- Add `omjobOperator.podSecurityContext` and `omjobOperator.securityContext` value keys (empty `{}` defaults) to the `openmetadata` chart, mirroring the pattern already used for the main server Deployment (`.Values.podSecurityContext` / `.Values.securityContext`).
- Wire both keys into `templates/omjob-operator-deployment.yaml` via `{{- with .Values… }}` blocks so nothing renders when unset — **zero diff in `helm template` output for existing installs**.
- Extend `values.schema.json` accordingly (required since the `omjobOperator` block uses `additionalProperties: false`).

## Motivation

Today `templates/omjob-operator-deployment.yaml` renders no `securityContext` and there's no values key to inject one. With `omjobOperator.enabled: true` and namespace label `pod-security.kubernetes.io/enforce=restricted`, the operator pod fails admission with at least:

- `autogen-disallow-privilege-escalation`
- `autogen-require-drop-all-capabilities`
- `autogen-require-seccomp-runtimedefault`

The only existing workarounds are: disable the operator (lose guaranteed exit-handler), apply post-render kustomize at deploy time, or fork the chart. This PR adds the same minimal `{{- with .Values… }}` pattern already in `templates/deployment.yaml` (lines 35–37, 44–46) so users can opt into PSS Restricted without any of the above.

## Backwards compatibility

- Defaults are `{}`. Wrapped in `{{- with .Values… }}` so when empty, nothing renders.
- **Zero diff in `helm template` output for existing installs that don't set the new keys.**
- No values renames or removals. Pure addition.

## Test plan

- [x] `helm template … --set omjobOperator.enabled=true` → operator Deployment renders without `securityContext` (current behavior, unchanged)
- [x] `helm template … --set omjobOperator.enabled=true -f restricted.yaml` (where `restricted.yaml` populates both new keys per the values.yaml example) → operator Deployment renders pod-level + container-level `securityContext` blocks with exactly the supplied values
- [x] `helm lint charts/openmetadata` passes in both configurations
- [ ] (optional) Render with a Namespace labeled `pod-security.kubernetes.io/enforce=restricted` and pipe through `kyverno apply` against the upstream PSS Restricted ClusterPolicy bundle — expect 0 failures on the operator Deployment with `restricted.yaml`

## Out of scope (separate PRs worth raising later)

These are real but bigger and orthogonal — splitting them keeps this PR small and easy to merge:

1. **Operator CR-access RBAC could become namespace-scoped.** `templates/omjob-operator-rbac.yaml` hardcodes a `ClusterRole` + `ClusterRoleBinding` for `pipelines.openmetadata.org/{omjobs,cronomjobs}`. Both CRDs are `scope: Namespaced`, so when `watchNamespaces` is a single namespace a `Role` + `RoleBinding` would suffice — eliminating the last cluster-scoped objects the chart requires. Needs operator-runtime confirmation that single-namespace `Role`-based watches work (controller-runtime usually does, with `cache.Options.DefaultNamespaces`).
2. **`templates/tests/test-connection.yaml` hardcodes `image: busybox`** with no values key to override the registry. Blocks airgapped `helm test`. One-line fix: `image: "{{ .Values.test.image | default "busybox" }}"` plus a `test.image` default in `values.yaml`.