### PR TITLE
ci: add PSA Restricted install check (kind + kyverno)

### DIFF
--- a/.github/workflows/psa-restricted.yml
+++ b/.github/workflows/psa-restricted.yml
@@ -12,15 +12,6 @@ on:
 jobs:
   psa-check:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        # Pin against multiple k8s minor versions so PSS-version drift
-        # surfaces here, not in production.
-        node-image:
-          - kindest/node:v1.32.5
-          - kindest/node:v1.33.1
-          - kindest/node:v1.34.0
     steps:
       - uses: actions/checkout@v4
 
@@ -34,16 +25,29 @@ jobs:
         with:
           install_only: true
 
-      - name: Run PSA restricted check
-        env:
-          KIND_NODE_IMAGE: ${{ matrix.node-image }}
+      - name: Install kyverno CLI
+        run: |
+          KYVERNO_VERSION="${KYVERNO_VERSION:-v1.13.4}"
+          curl -fsSL -o /tmp/kyverno.tgz \
+            "https://github.com/kyverno/kyverno/releases/download/${KYVERNO_VERSION}/kyverno-cli_${KYVERNO_VERSION}_linux_x86_64.tar.gz"
+          tar -xzf /tmp/kyverno.tgz -C /tmp kyverno
+          sudo mv /tmp/kyverno /usr/local/bin/
+          kyverno version
+
+      - name: Cache kyverno policies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/kyverno-policies
+          key: kyverno-policies-release-1.13
+
+      - name: Run PSA restricted check (kind + kyverno)
         run: bash scripts/test-psa-restricted.sh
 
       - name: Upload report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: psa-report-${{ strategy.job-index }}
+          name: psa-report
           path: psa-report/
           retention-days: 14
 

--- a/.github/workflows/psa-restricted.yml
+++ b/.github/workflows/psa-restricted.yml
@@ -1,0 +1,55 @@
+name: PSA Restricted Install Check
+
+on:
+  pull_request:
+    paths:
+      - 'charts/openmetadata/**'
+      - 'tests/psa-restricted/**'
+      - 'scripts/test-psa-restricted.sh'
+      - '.github/workflows/psa-restricted.yml'
+  workflow_dispatch:
+
+jobs:
+  psa-check:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Pin against multiple k8s minor versions so PSS-version drift
+        # surfaces here, not in production.
+        node-image:
+          - kindest/node:v1.32.5
+          - kindest/node:v1.33.1
+          - kindest/node:v1.34.0
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      - name: Install kind
+        uses: helm/kind-action@v1
+        with:
+          install_only: true
+
+      - name: Run PSA restricted check
+        env:
+          KIND_NODE_IMAGE: ${{ matrix.node-image }}
+        run: bash scripts/test-psa-restricted.sh
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: psa-report-${{ strategy.job-index }}
+          path: psa-report/
+          retention-days: 14
+
+      - name: Surface report in job summary
+        if: always()
+        run: |
+          if [[ -f psa-report/psa-report.md ]]; then
+            cat psa-report/psa-report.md >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ values-openshift-deps.yaml
 values-openshift.yaml
 docs/
 
+# Local PSA test reports
+psa-report/
+

--- a/scripts/test-psa-restricted.sh
+++ b/scripts/test-psa-restricted.sh
@@ -1,20 +1,34 @@
 #!/usr/bin/env bash
-# Render the openmetadata chart for each scenario in tests/psa-restricted/,
-# pipe it through `kubectl apply --dry-run=server` against a kind cluster
-# whose API server enforces Pod Security Standards "restricted" cluster-wide,
-# and emit a markdown report + JUnit XML.
+# Validate that charts/openmetadata can be installed under Pod Security Standards
+# "restricted" by exercising two complementary engines and emitting a single
+# combined report.
+#
+#   1. kind     — real K8s API server with PodSecurity admission enforcing
+#                 restricted:latest cluster-wide. Apply rendered manifests with
+#                 `kubectl apply --dry-run=server`; parse `Warning:` / `Forbidden`.
+#   2. kyverno  — offline `kyverno apply` against the upstream Pod Security
+#                 Standards restricted ClusterPolicy bundle (kyverno/policies).
+#                 Catches workload-template autogen rules that PSA only
+#                 enforces at actual Pod creation time.
+#
+# Both engines run per scenario; results are merged into psa-report/psa-report.md
+# (plus per-engine raw logs and a JUnit XML).
 #
 # Exit codes:
-#   0  no Forbidden, optionally no Warnings (see STRICT)
-#   1  at least one Forbidden in any non-baseline scenario
-#   2  setup error (kind/helm/kubectl missing, cluster create failed, etc.)
+#   0  every "pass"-expected scenario passes in every selected engine
+#   1  at least one engine failed an expected-pass scenario, or an expected-fail
+#      scenario stopped failing (regression detector)
+#   2  setup error (missing tool, cluster create failed, policy fetch failed)
 #
 # Env vars:
-#   STRICT=1            also fail on Warnings (default: only fail on Forbidden)
-#   KEEP_CLUSTER=1      don't delete the kind cluster on exit
-#   KIND_NODE_IMAGE     override kindest/node image (default: kind's bundled)
-#   REPORT_DIR          where to write reports (default: ./psa-report)
-#   CHART_DIR           chart path (default: ./charts/openmetadata)
+#   ENGINES=kind,kyverno        comma list; default "kind,kyverno"
+#   STRICT=1                    kind engine: fail on Warnings (default: only Forbidden)
+#   KEEP_CLUSTER=1              don't delete the kind cluster on exit
+#   KIND_NODE_IMAGE             override kindest/node image
+#   KYVERNO_POLICIES_REF        git ref of kyverno/policies (default: release-1.13)
+#   KYVERNO_POLICIES_CACHE      path to cached policies dir (default: ~/.cache/kyverno-policies)
+#   REPORT_DIR                  where to write reports (default: ./psa-report)
+#   CHART_DIR                   chart path (default: ./charts/openmetadata)
 
 set -euo pipefail
 
@@ -25,143 +39,271 @@ TESTS_DIR="tests/psa-restricted"
 REPORT_DIR="${REPORT_DIR:-./psa-report}"
 STRICT="${STRICT:-0}"
 KEEP_CLUSTER="${KEEP_CLUSTER:-0}"
+ENGINES="${ENGINES:-kind,kyverno}"
+KYVERNO_POLICIES_REF="${KYVERNO_POLICIES_REF:-release-1.13}"
+KYVERNO_POLICIES_CACHE="${KYVERNO_POLICIES_CACHE:-$HOME/.cache/kyverno-policies}"
 
-# Scenario name → values file. Baseline is expected to fail (regression catch).
 declare -a SCENARIO_NAMES=(baseline restricted)
 declare -A SCENARIO_FILES=(
   [baseline]="$TESTS_DIR/values-baseline.yaml"
   [restricted]="$TESTS_DIR/values-restricted.yaml"
 )
 declare -A SCENARIO_EXPECT=(
-  [baseline]=fail      # expected: PSA violations exist (proves test harness works)
-  [restricted]=pass    # expected: no violations
+  [baseline]=fail
+  [restricted]=pass
 )
 
+# Per-engine results: associative arrays keyed "<engine>:<scenario>"
+declare -A RES_STATUS    # PASS / FAIL …
+declare -A RES_W         # warnings/fail count (engine-defined)
+declare -A RES_E         # errors/forbid count (engine-defined)
+declare -A RES_DETAIL    # short detail block (markdown-ready)
+
 need() { command -v "$1" >/dev/null || { echo "missing: $1" >&2; exit 2; }; }
-need kind; need kubectl; need helm; need awk; need grep
+need helm; need awk; need grep; need sed
 
 mkdir -p "$REPORT_DIR"
 
 cleanup() {
-  if [[ "$KEEP_CLUSTER" != "1" ]]; then
+  if [[ "$KEEP_CLUSTER" != "1" ]] && command -v kind >/dev/null; then
     kind delete cluster --name "$CLUSTER" >/dev/null 2>&1 || true
   fi
 }
 trap cleanup EXIT
 
-# --- cluster setup ------------------------------------------------------------
-if ! kind get clusters 2>/dev/null | grep -qx "$CLUSTER"; then
-  echo "==> creating kind cluster '$CLUSTER' with PSA restricted enforce"
-  kind_args=(--name "$CLUSTER" --config "$TESTS_DIR/kind-psa.yaml" --wait 60s)
-  [[ -n "${KIND_NODE_IMAGE:-}" ]] && kind_args+=(--image "$KIND_NODE_IMAGE")
-  kind create cluster "${kind_args[@]}" >&2
-fi
-
-CTX="kind-$CLUSTER"
-kubectl --context "$CTX" create ns "$NS" --dry-run=client -o yaml | kubectl --context "$CTX" apply -f - >/dev/null
-
-# stub secrets so chart renders fully (passwords don't matter for dry-run)
-for s in mysql-secrets:openmetadata-mysql-password \
-         airflow-secrets:openmetadata-airflow-password \
-         airflow-mysql-secrets:airflow-mysql-password; do
-  name="${s%%:*}"; key="${s##*:}"
-  kubectl --context "$CTX" -n "$NS" create secret generic "$name" \
-    --from-literal="$key=stub" --dry-run=client -o yaml | \
-    kubectl --context "$CTX" -n "$NS" apply -f - >/dev/null
+# --- render all scenarios up front -------------------------------------------
+for name in "${SCENARIO_NAMES[@]}"; do
+  vfile="${SCENARIO_FILES[$name]}"
+  manifest="$REPORT_DIR/$name.manifest.yaml"
+  echo "==> rendering $name → $manifest"
+  helm template om "$CHART_DIR" --namespace "$NS" -f "$vfile" > "$manifest" 2>/dev/null
 done
 
-# --- per-scenario run ---------------------------------------------------------
-fail=0
+# --- engine: kind -------------------------------------------------------------
+run_engine_kind() {
+  need kind; need kubectl
+  if ! kind get clusters 2>/dev/null | grep -qx "$CLUSTER"; then
+    echo "==> [kind] creating cluster '$CLUSTER' with PSA restricted enforce"
+    local kind_args=(--name "$CLUSTER" --config "$TESTS_DIR/kind-psa.yaml" --wait 60s)
+    [[ -n "${KIND_NODE_IMAGE:-}" ]] && kind_args+=(--image "$KIND_NODE_IMAGE")
+    kind create cluster "${kind_args[@]}" >&2
+  fi
+
+  local CTX="kind-$CLUSTER"
+  kubectl --context "$CTX" create ns "$NS" --dry-run=client -o yaml | kubectl --context "$CTX" apply -f - >/dev/null
+
+  for s in mysql-secrets:openmetadata-mysql-password \
+           airflow-secrets:openmetadata-airflow-password \
+           airflow-mysql-secrets:airflow-mysql-password; do
+    local name="${s%%:*}"; local key="${s##*:}"
+    kubectl --context "$CTX" -n "$NS" create secret generic "$name" \
+      --from-literal="$key=stub" --dry-run=client -o yaml | \
+      kubectl --context "$CTX" -n "$NS" apply -f - >/dev/null
+  done
+
+  for scenario in "${SCENARIO_NAMES[@]}"; do
+    local manifest="$REPORT_DIR/$scenario.manifest.yaml"
+    local applylog="$REPORT_DIR/kind.$scenario.log"
+    set +e
+    kubectl --context "$CTX" -n "$NS" apply -f "$manifest" --dry-run=server >"$applylog" 2>&1
+    set -e
+
+    local warn forbid
+    warn=$(grep -c '^Warning:' "$applylog" || true)
+    forbid=$(grep -c 'Forbidden' "$applylog" || true)
+
+    local expect="${SCENARIO_EXPECT[$scenario]}"
+    local status
+    if [[ "$expect" == "pass" ]]; then
+      if (( forbid > 0 )) || { [[ "$STRICT" == "1" ]] && (( warn > 0 )); }; then
+        status="FAIL"
+      else
+        status="PASS"
+      fi
+    else
+      if (( warn == 0 && forbid == 0 )); then
+        status="FAIL (expected violations, got none)"
+      else
+        status="PASS (violations as expected)"
+      fi
+    fi
+
+    RES_STATUS["kind:$scenario"]=$status
+    RES_W["kind:$scenario"]=$warn
+    RES_E["kind:$scenario"]=$forbid
+
+    if (( warn + forbid > 0 )); then
+      RES_DETAIL["kind:$scenario"]=$(grep -E '^(Warning:|Error from server \(Forbidden\))' "$applylog" \
+        | sed -e 's/^Warning: would violate PodSecurity "[^"]*": /  warning: /' \
+              -e 's/^Error from server (Forbidden): /  forbidden: /')
+    fi
+  done
+}
+
+# --- engine: kyverno ----------------------------------------------------------
+ensure_kyverno_policies() {
+  if [[ -d "$KYVERNO_POLICIES_CACHE/$KYVERNO_POLICIES_REF" ]]; then
+    echo "==> [kyverno] using cached policies at $KYVERNO_POLICIES_CACHE/$KYVERNO_POLICIES_REF"
+    return
+  fi
+  echo "==> [kyverno] fetching kyverno/policies@$KYVERNO_POLICIES_REF"
+  mkdir -p "$KYVERNO_POLICIES_CACHE"
+  local tmp; tmp=$(mktemp -d)
+  git clone --depth=1 --branch "$KYVERNO_POLICIES_REF" \
+    https://github.com/kyverno/policies.git "$tmp/repo" >/dev/null 2>&1 || {
+      echo "failed to clone kyverno/policies@$KYVERNO_POLICIES_REF" >&2
+      exit 2
+    }
+  mv "$tmp/repo" "$KYVERNO_POLICIES_CACHE/$KYVERNO_POLICIES_REF"
+}
+
+flatten_kyverno_policies() {
+  local src="$KYVERNO_POLICIES_CACHE/$KYVERNO_POLICIES_REF/pod-security"
+  local dst="$REPORT_DIR/kyverno-policies"
+  rm -rf "$dst"; mkdir -p "$dst"
+  /usr/bin/find "$src/restricted" "$src/baseline" -mindepth 2 -maxdepth 2 -name '*.yaml' | \
+    while IFS= read -r f; do
+      cp "$f" "$dst/"
+    done
+  echo "$dst"
+}
+
+run_engine_kyverno() {
+  need kyverno; need git
+  ensure_kyverno_policies
+  local policy_dir; policy_dir=$(flatten_kyverno_policies)
+
+  for scenario in "${SCENARIO_NAMES[@]}"; do
+    local manifest="$REPORT_DIR/$scenario.manifest.yaml"
+    local applylog="$REPORT_DIR/kyverno.$scenario.log"
+    set +e
+    kyverno apply "$policy_dir" --resource "$manifest" > "$applylog" 2>&1
+    set -e
+
+    # parse summary line: "pass: N, fail: N, warn: N, error: N, skip: N"
+    local summary fails passes
+    summary=$(grep -E '^pass:' "$applylog" | tail -1 || true)
+    if [[ -z "$summary" ]]; then
+      RES_STATUS["kyverno:$scenario"]="FAIL (kyverno apply produced no summary)"
+      RES_W["kyverno:$scenario"]=0
+      RES_E["kyverno:$scenario"]=0
+      RES_DETAIL["kyverno:$scenario"]="kyverno output truncated; see kyverno.$scenario.log"
+      continue
+    fi
+    fails=$(echo "$summary" | sed -E 's/.*fail: ([0-9]+).*/\1/')
+    passes=$(echo "$summary" | sed -E 's/.*pass: ([0-9]+).*/\1/')
+
+    local expect="${SCENARIO_EXPECT[$scenario]}"
+    local status
+    if [[ "$expect" == "pass" ]]; then
+      if (( fails > 0 )); then
+        status="FAIL"
+      else
+        status="PASS"
+      fi
+    else
+      if (( fails == 0 )); then
+        status="FAIL (expected violations, got none)"
+      else
+        status="PASS (violations as expected)"
+      fi
+    fi
+
+    RES_STATUS["kyverno:$scenario"]=$status
+    RES_W["kyverno:$scenario"]=$passes
+    RES_E["kyverno:$scenario"]=$fails
+
+    if (( fails > 0 )); then
+      # show first ~10 unique failure rules
+      RES_DETAIL["kyverno:$scenario"]=$(grep -E '^policy ' "$applylog" | head -10 | sed 's/^/  /')
+    fi
+  done
+}
+
+# --- run selected engines -----------------------------------------------------
+IFS=',' read -ra engine_list <<< "$ENGINES"
+for e in "${engine_list[@]}"; do
+  case "$e" in
+    kind)    run_engine_kind ;;
+    kyverno) run_engine_kyverno ;;
+    *) echo "unknown engine: $e" >&2; exit 2 ;;
+  esac
+done
+
+# --- combined report ----------------------------------------------------------
 report="$REPORT_DIR/psa-report.md"
 junit="$REPORT_DIR/psa-report.junit.xml"
+overall_fail=0
 
 {
   echo "# PSA Restricted install check"
   echo
-  echo "Chart: \`$CHART_DIR\`  •  Cluster PSA: \`enforce=restricted:latest\`  •  Generated: \`$(date -u +%FT%TZ)\`"
+  echo "Chart: \`$CHART_DIR\`  •  Engines: \`$ENGINES\`  •  Generated: \`$(date -u +%FT%TZ)\`"
+  echo
+  echo "## Result matrix"
+  echo
+  printf "| scenario |"
+  for e in "${engine_list[@]}"; do printf " %s |" "$e"; done
+  echo
+  printf "| --- |"
+  for _ in "${engine_list[@]}"; do printf " --- |"; done
+  echo
+  for s in "${SCENARIO_NAMES[@]}"; do
+    printf "| \`%s\` |" "$s"
+    for e in "${engine_list[@]}"; do
+      printf " %s |" "${RES_STATUS[$e:$s]:-—}"
+    done
+    echo
+  done
   echo
 } > "$report"
 
 junit_cases=""
-total_warn=0; total_forbid=0
-
-for name in "${SCENARIO_NAMES[@]}"; do
-  vfile="${SCENARIO_FILES[$name]}"
-  expect="${SCENARIO_EXPECT[$name]}"
-  echo "==> scenario: $name  (values=$vfile, expect=$expect)"
-
-  manifest="$REPORT_DIR/$name.manifest.yaml"
-  applylog="$REPORT_DIR/$name.apply.log"
-
-  helm template om "$CHART_DIR" --namespace "$NS" -f "$vfile" > "$manifest" 2>/dev/null
-
-  set +e
-  kubectl --context "$CTX" -n "$NS" apply -f "$manifest" --dry-run=server >"$applylog" 2>&1
-  set -e
-
-  warn=$(grep -c '^Warning:' "$applylog" || true)
-  forbid=$(grep -c 'Forbidden' "$applylog" || true)
-  total_warn=$((total_warn + warn))
-  total_forbid=$((total_forbid + forbid))
-
-  # determine pass/fail per scenario
-  if [[ "$expect" == "pass" ]]; then
-    if (( forbid > 0 )) || { [[ "$STRICT" == "1" ]] && (( warn > 0 )); }; then
-      status="FAIL"; fail=1
-    else
-      status="PASS"
-    fi
-  else
-    # baseline: we *expect* violations; treat absence of any as suspicious
-    if (( warn == 0 && forbid == 0 )); then
-      status="FAIL (expected violations, got none — chart may have changed)"
-      fail=1
-    else
-      status="PASS (violations present as expected)"
-    fi
-  fi
-
-  {
-    echo "## Scenario: \`$name\`  —  $status"
-    echo
-    echo "- values: \`$vfile\`"
-    echo "- expectation: \`$expect\`"
-    echo "- warnings: **$warn**"
-    echo "- forbidden: **$forbid**"
-    echo
-    if (( warn + forbid > 0 )); then
-      echo "<details><summary>violation detail</summary>"
+for s in "${SCENARIO_NAMES[@]}"; do
+  for e in "${engine_list[@]}"; do
+    status="${RES_STATUS[$e:$s]:-—}"
+    {
+      echo "### \`$e\` × \`$s\` — $status"
       echo
-      echo '```'
-      grep -E '^(Warning:|Error from server \(Forbidden\))' "$applylog" | sed -e 's/^Warning: would violate PodSecurity "[^"]*": /  warning: /' || true
-      echo '```'
+      if [[ "$e" == kind ]]; then
+        echo "- warnings: **${RES_W[$e:$s]:-0}**, forbidden: **${RES_E[$e:$s]:-0}**"
+      else
+        echo "- policy-rule passes: **${RES_W[$e:$s]:-0}**, fails: **${RES_E[$e:$s]:-0}**"
+      fi
+      if [[ -n "${RES_DETAIL[$e:$s]:-}" ]]; then
+        echo
+        echo "<details><summary>detail</summary>"
+        echo
+        echo '```'
+        echo "${RES_DETAIL[$e:$s]}"
+        echo '```'
+        echo
+        echo "</details>"
+      fi
       echo
-      echo "</details>"
-      echo
-    fi
-  } >> "$report"
+    } >> "$report"
 
-  # JUnit case
-  case_xml="<testcase classname=\"psa-restricted\" name=\"$name\" time=\"0\">"
-  if [[ "$status" == FAIL* ]]; then
-    body=$(grep -E '^(Warning:|Error from server \(Forbidden\))' "$applylog" | head -20 | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
-    case_xml+="<failure message=\"$status\">${body}</failure>"
-  fi
-  case_xml+="</testcase>"
-  junit_cases+="$case_xml"
+    # JUnit
+    case_xml="<testcase classname=\"psa-restricted.$e\" name=\"$s\" time=\"0\">"
+    if [[ "$status" == FAIL* ]]; then
+      overall_fail=1
+      body=$(echo "${RES_DETAIL[$e:$s]:-$status}" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
+      case_xml+="<failure message=\"$status\">${body}</failure>"
+    fi
+    case_xml+="</testcase>"
+    junit_cases+="$case_xml"
+  done
 done
 
 {
   echo "## Summary"
   echo
-  echo "- total warnings: **$total_warn**"
-  echo "- total forbidden: **$total_forbid**"
-  echo "- overall: $([[ $fail -eq 0 ]] && echo PASS || echo FAIL)"
+  echo "- overall: $([[ $overall_fail -eq 0 ]] && echo PASS || echo FAIL)"
 } >> "$report"
 
 {
   echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-  echo "<testsuite name=\"psa-restricted\" tests=\"${#SCENARIO_NAMES[@]}\" failures=\"$([[ $fail -eq 0 ]] && echo 0 || echo 1)\">"
+  echo "<testsuite name=\"psa-restricted\" tests=\"$((${#SCENARIO_NAMES[@]} * ${#engine_list[@]}))\" failures=\"$overall_fail\">"
   echo "$junit_cases"
   echo "</testsuite>"
 } > "$junit"
@@ -170,4 +312,4 @@ echo
 echo "==> report: $report"
 echo "==> junit:  $junit"
 
-exit $fail
+exit $overall_fail

--- a/scripts/test-psa-restricted.sh
+++ b/scripts/test-psa-restricted.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Render the openmetadata chart for each scenario in tests/psa-restricted/,
+# pipe it through `kubectl apply --dry-run=server` against a kind cluster
+# whose API server enforces Pod Security Standards "restricted" cluster-wide,
+# and emit a markdown report + JUnit XML.
+#
+# Exit codes:
+#   0  no Forbidden, optionally no Warnings (see STRICT)
+#   1  at least one Forbidden in any non-baseline scenario
+#   2  setup error (kind/helm/kubectl missing, cluster create failed, etc.)
+#
+# Env vars:
+#   STRICT=1            also fail on Warnings (default: only fail on Forbidden)
+#   KEEP_CLUSTER=1      don't delete the kind cluster on exit
+#   KIND_NODE_IMAGE     override kindest/node image (default: kind's bundled)
+#   REPORT_DIR          where to write reports (default: ./psa-report)
+#   CHART_DIR           chart path (default: ./charts/openmetadata)
+
+set -euo pipefail
+
+CLUSTER=psa-test
+NS=openmetadata
+CHART_DIR="${CHART_DIR:-./charts/openmetadata}"
+TESTS_DIR="tests/psa-restricted"
+REPORT_DIR="${REPORT_DIR:-./psa-report}"
+STRICT="${STRICT:-0}"
+KEEP_CLUSTER="${KEEP_CLUSTER:-0}"
+
+# Scenario name → values file. Baseline is expected to fail (regression catch).
+declare -a SCENARIO_NAMES=(baseline restricted)
+declare -A SCENARIO_FILES=(
+  [baseline]="$TESTS_DIR/values-baseline.yaml"
+  [restricted]="$TESTS_DIR/values-restricted.yaml"
+)
+declare -A SCENARIO_EXPECT=(
+  [baseline]=fail      # expected: PSA violations exist (proves test harness works)
+  [restricted]=pass    # expected: no violations
+)
+
+need() { command -v "$1" >/dev/null || { echo "missing: $1" >&2; exit 2; }; }
+need kind; need kubectl; need helm; need awk; need grep
+
+mkdir -p "$REPORT_DIR"
+
+cleanup() {
+  if [[ "$KEEP_CLUSTER" != "1" ]]; then
+    kind delete cluster --name "$CLUSTER" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+# --- cluster setup ------------------------------------------------------------
+if ! kind get clusters 2>/dev/null | grep -qx "$CLUSTER"; then
+  echo "==> creating kind cluster '$CLUSTER' with PSA restricted enforce"
+  kind_args=(--name "$CLUSTER" --config "$TESTS_DIR/kind-psa.yaml" --wait 60s)
+  [[ -n "${KIND_NODE_IMAGE:-}" ]] && kind_args+=(--image "$KIND_NODE_IMAGE")
+  kind create cluster "${kind_args[@]}" >&2
+fi
+
+CTX="kind-$CLUSTER"
+kubectl --context "$CTX" create ns "$NS" --dry-run=client -o yaml | kubectl --context "$CTX" apply -f - >/dev/null
+
+# stub secrets so chart renders fully (passwords don't matter for dry-run)
+for s in mysql-secrets:openmetadata-mysql-password \
+         airflow-secrets:openmetadata-airflow-password \
+         airflow-mysql-secrets:airflow-mysql-password; do
+  name="${s%%:*}"; key="${s##*:}"
+  kubectl --context "$CTX" -n "$NS" create secret generic "$name" \
+    --from-literal="$key=stub" --dry-run=client -o yaml | \
+    kubectl --context "$CTX" -n "$NS" apply -f - >/dev/null
+done
+
+# --- per-scenario run ---------------------------------------------------------
+fail=0
+report="$REPORT_DIR/psa-report.md"
+junit="$REPORT_DIR/psa-report.junit.xml"
+
+{
+  echo "# PSA Restricted install check"
+  echo
+  echo "Chart: \`$CHART_DIR\`  •  Cluster PSA: \`enforce=restricted:latest\`  •  Generated: \`$(date -u +%FT%TZ)\`"
+  echo
+} > "$report"
+
+junit_cases=""
+total_warn=0; total_forbid=0
+
+for name in "${SCENARIO_NAMES[@]}"; do
+  vfile="${SCENARIO_FILES[$name]}"
+  expect="${SCENARIO_EXPECT[$name]}"
+  echo "==> scenario: $name  (values=$vfile, expect=$expect)"
+
+  manifest="$REPORT_DIR/$name.manifest.yaml"
+  applylog="$REPORT_DIR/$name.apply.log"
+
+  helm template om "$CHART_DIR" --namespace "$NS" -f "$vfile" > "$manifest" 2>/dev/null
+
+  set +e
+  kubectl --context "$CTX" -n "$NS" apply -f "$manifest" --dry-run=server >"$applylog" 2>&1
+  set -e
+
+  warn=$(grep -c '^Warning:' "$applylog" || true)
+  forbid=$(grep -c 'Forbidden' "$applylog" || true)
+  total_warn=$((total_warn + warn))
+  total_forbid=$((total_forbid + forbid))
+
+  # determine pass/fail per scenario
+  if [[ "$expect" == "pass" ]]; then
+    if (( forbid > 0 )) || { [[ "$STRICT" == "1" ]] && (( warn > 0 )); }; then
+      status="FAIL"; fail=1
+    else
+      status="PASS"
+    fi
+  else
+    # baseline: we *expect* violations; treat absence of any as suspicious
+    if (( warn == 0 && forbid == 0 )); then
+      status="FAIL (expected violations, got none — chart may have changed)"
+      fail=1
+    else
+      status="PASS (violations present as expected)"
+    fi
+  fi
+
+  {
+    echo "## Scenario: \`$name\`  —  $status"
+    echo
+    echo "- values: \`$vfile\`"
+    echo "- expectation: \`$expect\`"
+    echo "- warnings: **$warn**"
+    echo "- forbidden: **$forbid**"
+    echo
+    if (( warn + forbid > 0 )); then
+      echo "<details><summary>violation detail</summary>"
+      echo
+      echo '```'
+      grep -E '^(Warning:|Error from server \(Forbidden\))' "$applylog" | sed -e 's/^Warning: would violate PodSecurity "[^"]*": /  warning: /' || true
+      echo '```'
+      echo
+      echo "</details>"
+      echo
+    fi
+  } >> "$report"
+
+  # JUnit case
+  case_xml="<testcase classname=\"psa-restricted\" name=\"$name\" time=\"0\">"
+  if [[ "$status" == FAIL* ]]; then
+    body=$(grep -E '^(Warning:|Error from server \(Forbidden\))' "$applylog" | head -20 | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
+    case_xml+="<failure message=\"$status\">${body}</failure>"
+  fi
+  case_xml+="</testcase>"
+  junit_cases+="$case_xml"
+done
+
+{
+  echo "## Summary"
+  echo
+  echo "- total warnings: **$total_warn**"
+  echo "- total forbidden: **$total_forbid**"
+  echo "- overall: $([[ $fail -eq 0 ]] && echo PASS || echo FAIL)"
+} >> "$report"
+
+{
+  echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+  echo "<testsuite name=\"psa-restricted\" tests=\"${#SCENARIO_NAMES[@]}\" failures=\"$([[ $fail -eq 0 ]] && echo 0 || echo 1)\">"
+  echo "$junit_cases"
+  echo "</testsuite>"
+} > "$junit"
+
+echo
+echo "==> report: $report"
+echo "==> junit:  $junit"
+
+exit $fail

--- a/tests/psa-restricted/README.md
+++ b/tests/psa-restricted/README.md
@@ -2,52 +2,73 @@
 
 Validates that `charts/openmetadata` can be installed into a namespace
 that enforces the [Pod Security Standards "restricted"](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
-profile.
+profile, using two complementary policy engines.
 
-## What it does
+## Engines
 
-For each scenario in `values-*.yaml`:
+### `kind` — real K8s API server fidelity
 
-1. Render the chart with `helm template … -f <values>.yaml`.
-2. Apply the rendered manifest with `kubectl apply --dry-run=server` against a
-   kind cluster whose API server enforces `restricted:latest` cluster-wide.
-3. Parse stderr for `Warning:` and `Forbidden` from the PodSecurity admission
-   plugin, group by resource, and emit a markdown + JUnit report.
+Spins up a kind cluster whose API server runs the in-tree `PodSecurity`
+admission plugin with `enforce=restricted:latest` cluster-wide (via an
+`AdmissionConfiguration` mounted into the control-plane container — no
+need to label namespaces individually).
 
-The kind cluster gets the PSA cluster-wide default via an
-`AdmissionConfiguration` mounted into the control-plane container, so we don't
-have to remember to label every namespace.
+For each scenario, renders the chart with `helm template`, applies it
+with `kubectl apply --dry-run=server`, and parses stderr for `Warning:`
+and `Forbidden`. **Limitation:** PSA only *enforces* at Pod creation; for
+workload templates (Deployment, CronJob), violations show up as `Warning:`
+rather than `Forbidden`. The harness counts both.
+
+### `kyverno` — offline, autogen-rule coverage
+
+Runs `kyverno apply` against the upstream PSS Restricted ClusterPolicy
+bundle from `kyverno/policies@release-1.13`. Kyverno generates `autogen-*`
+variants of each Pod-level rule for every workload kind (Deployment,
+DaemonSet, CronJob, …), so it catches the same workload-template
+violations as `Forbidden`, not just `Warning:` — useful in CI where you
+want any non-compliant pod template to fail the build.
+
+No cluster needed; runs in ~5s once policies are cached. Catches things
+PSA's PodSecurity admission alone won't flag at apply time.
 
 ## Scenarios
 
 | Scenario | Values | Expectation |
 | --- | --- | --- |
-| `baseline` | `values-baseline.yaml` — `omjobOperator.enabled=true`, no securityContext | **fail** — must show PSA violations. Regression catch: if this starts passing, either the chart has tightened defaults or PSA has loosened, either way worth knowing. |
-| `restricted` | `values-restricted.yaml` — full PSS-restricted securityContext on main + omjobOperator | **pass** — zero `Forbidden`. With `STRICT=1`, also zero `Warning:`. |
+| `baseline` | `values-baseline.yaml` — `omjobOperator.enabled=true`, no `securityContext` overrides | **fail** — must show violations. Regression catch in both directions. |
+| `restricted` | `values-restricted.yaml` — full PSS-restricted `securityContext` on main + `omjobOperator` | **pass** — zero `Forbidden`/policy-fails. With `STRICT=1`, also zero `Warning:` (kind). |
 
 ## Run locally
 
 ```bash
-# need: docker, kind, kubectl, helm
+# need: docker, kind, kubectl, helm, kyverno, git
 bash scripts/test-psa-restricted.sh
 
-# strict (fail on Warnings, not just Forbidden):
+# just one engine:
+ENGINES=kind    bash scripts/test-psa-restricted.sh
+ENGINES=kyverno bash scripts/test-psa-restricted.sh
+
+# strict (kind engine fails on Warnings, not just Forbidden):
 STRICT=1 bash scripts/test-psa-restricted.sh
 
 # keep cluster around for poking:
 KEEP_CLUSTER=1 bash scripts/test-psa-restricted.sh
+
+# pin a different kyverno/policies ref:
+KYVERNO_POLICIES_REF=release-1.14 bash scripts/test-psa-restricted.sh
 ```
 
 Reports land in `./psa-report/`:
 
-- `psa-report.md` — human-readable
-- `psa-report.junit.xml` — for CI test reporters
-- `<scenario>.manifest.yaml` — rendered chart per scenario
-- `<scenario>.apply.log` — raw `kubectl apply --dry-run=server` output
+- `psa-report.md` — human-readable combined report (matrix table + per-cell detail)
+- `psa-report.junit.xml` — `psa-restricted.<engine>` testcases, consumable by CI test reporters
+- `<scenario>.manifest.yaml` — rendered chart per scenario (shared across engines)
+- `kind.<scenario>.log` — raw `kubectl apply --dry-run=server` output
+- `kyverno.<scenario>.log` — raw `kyverno apply` output
 
 ## CI
 
 Wired up in `.github/workflows/psa-restricted.yml`. Runs on PRs that touch
-the chart, the test fixtures, the script, or the workflow itself. Matrix
-runs three kindest/node minor versions in parallel to catch PSS-version
-drift early.
+the chart, the test fixtures, the script, or the workflow itself. Single
+job runs both engines and emits a combined report into the job summary.
+Kyverno policies are cached across runs via `actions/cache`.

--- a/tests/psa-restricted/README.md
+++ b/tests/psa-restricted/README.md
@@ -1,0 +1,53 @@
+# PSA Restricted install check
+
+Validates that `charts/openmetadata` can be installed into a namespace
+that enforces the [Pod Security Standards "restricted"](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+profile.
+
+## What it does
+
+For each scenario in `values-*.yaml`:
+
+1. Render the chart with `helm template … -f <values>.yaml`.
+2. Apply the rendered manifest with `kubectl apply --dry-run=server` against a
+   kind cluster whose API server enforces `restricted:latest` cluster-wide.
+3. Parse stderr for `Warning:` and `Forbidden` from the PodSecurity admission
+   plugin, group by resource, and emit a markdown + JUnit report.
+
+The kind cluster gets the PSA cluster-wide default via an
+`AdmissionConfiguration` mounted into the control-plane container, so we don't
+have to remember to label every namespace.
+
+## Scenarios
+
+| Scenario | Values | Expectation |
+| --- | --- | --- |
+| `baseline` | `values-baseline.yaml` — `omjobOperator.enabled=true`, no securityContext | **fail** — must show PSA violations. Regression catch: if this starts passing, either the chart has tightened defaults or PSA has loosened, either way worth knowing. |
+| `restricted` | `values-restricted.yaml` — full PSS-restricted securityContext on main + omjobOperator | **pass** — zero `Forbidden`. With `STRICT=1`, also zero `Warning:`. |
+
+## Run locally
+
+```bash
+# need: docker, kind, kubectl, helm
+bash scripts/test-psa-restricted.sh
+
+# strict (fail on Warnings, not just Forbidden):
+STRICT=1 bash scripts/test-psa-restricted.sh
+
+# keep cluster around for poking:
+KEEP_CLUSTER=1 bash scripts/test-psa-restricted.sh
+```
+
+Reports land in `./psa-report/`:
+
+- `psa-report.md` — human-readable
+- `psa-report.junit.xml` — for CI test reporters
+- `<scenario>.manifest.yaml` — rendered chart per scenario
+- `<scenario>.apply.log` — raw `kubectl apply --dry-run=server` output
+
+## CI
+
+Wired up in `.github/workflows/psa-restricted.yml`. Runs on PRs that touch
+the chart, the test fixtures, the script, or the workflow itself. Matrix
+runs three kindest/node minor versions in parallel to catch PSS-version
+drift early.

--- a/tests/psa-restricted/kind-psa.yaml
+++ b/tests/psa-restricted/kind-psa.yaml
@@ -1,0 +1,20 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        admission-control-config-file: /etc/config/psa-admission.yaml
+      extraVolumes:
+      - name: admission-config
+        hostPath: /etc/config
+        mountPath: /etc/config
+        readOnly: true
+        pathType: DirectoryOrCreate
+  extraMounts:
+  - hostPath: ./tests/psa-restricted
+    containerPath: /etc/config
+    readOnly: true

--- a/tests/psa-restricted/psa-admission.yaml
+++ b/tests/psa-restricted/psa-admission.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+- name: PodSecurity
+  configuration:
+    apiVersion: pod-security.admission.config.k8s.io/v1
+    kind: PodSecurityConfiguration
+    defaults:
+      enforce: "restricted"
+      enforce-version: "latest"
+      audit: "restricted"
+      audit-version: "latest"
+      warn: "restricted"
+      warn-version: "latest"
+    exemptions:
+      usernames: []
+      runtimeClasses: []
+      namespaces:
+      - kube-system
+      - kube-public
+      - kube-node-lease
+      - local-path-storage

--- a/tests/psa-restricted/values-baseline.yaml
+++ b/tests/psa-restricted/values-baseline.yaml
@@ -1,0 +1,2 @@
+omjobOperator:
+  enabled: true

--- a/tests/psa-restricted/values-restricted.yaml
+++ b/tests/psa-restricted/values-restricted.yaml
@@ -1,0 +1,34 @@
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: [ALL]
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+omjobOperator:
+  enabled: true
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: [ALL]
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault


### PR DESCRIPTION
## Summary

Adds a CI check that validates `charts/openmetadata` against Pod Security Standards "restricted" using **two complementary policy engines**:

| Engine | What it does | Catches |
| --- | --- | --- |
| **kind** | Real K8s API server with PodSecurity admission enforcing `restricted:latest` cluster-wide. Apply rendered manifests with `kubectl apply --dry-run=server`. | True admission-controller fidelity; matches what users will hit in production on PSS-enforced clusters. |
| **kyverno** | Offline `kyverno apply` against `kyverno/policies@release-1.13` PSS Restricted ClusterPolicy bundle, fetched at runtime and cached. | Workload-template `autogen-*` variants of each rule, which PSA's PodSecurity plugin only enforces at actual Pod creation. Surfaces chart-rendering quirks PSA tolerates. |

Both engines run per scenario; results are merged into a single Markdown matrix + JUnit XML. Single workflow job; combined report is artifacted and inlined into the GHA job summary.

## Scenarios

| Scenario | Values | Expectation |
| --- | --- | --- |
| `baseline` | `omjobOperator.enabled=true`, no `securityContext` overrides | **fail** — must show violations (regression catch in both directions) |
| `restricted` | Full pod- and container-level `securityContext` on main + `omjobOperator`, including `seccompProfile: RuntimeDefault` | **pass** — zero `Forbidden`/policy-fails |

## Local results

```
| scenario   | kind                              | kyverno                           |
| ---        | ---                               | ---                               |
| baseline   | PASS (violations as expected)     | PASS (violations as expected)     |
| restricted | PASS                              | FAIL — see "Known finding" below  |
overall: FAIL
```

## ⚠️ Known finding: the test is intentionally red on day 1

`restricted × kyverno` fails on **`disallow-host-path` against `Deployment/openmetadata`**. Root cause is a pre-existing chart-rendering quirk, not a securityContext gap:

`charts/openmetadata/templates/deployment.yaml:119` emits `volumes:` unconditionally:

```yaml
      volumes:
      {{- if .Values.extraVolumes }}
      ...
      {{- end }}
      {{- if (((.Values.openmetadata.config.pipelineServiceClientConfig).argoWorkflows).customConfig).enabled }}
      ...
      {{- end }}
```

When neither `extraVolumes` nor the `customConfig` configmap is set (the common case), the rendered output is a bare `volumes:` key with no list — equivalent to `volumes: null`. PSA's PodSecurity admission tolerates this silently; kyverno's autogen `disallow-host-path` rule trips on it.

**This PR leaves the CI red on this finding deliberately**, as a forcing function for the trivial chart fix:

```diff
+      {{- if or .Values.extraVolumes (((.Values.openmetadata.config.pipelineServiceClientConfig).argoWorkflows).customConfig).enabled }}
       volumes:
       {{- if .Values.extraVolumes }}
       ...
       {{- end }}
       {{- if (((.Values.openmetadata.config.pipelineServiceClientConfig).argoWorkflows).customConfig).enabled }}
       ...
       {{- end }}
+      {{- end }}
```

Flipping `restricted × kyverno` green is the acceptance criterion for the follow-up chart PR.

## Files

- `scripts/test-psa-restricted.sh` — runner. Env knobs: `ENGINES=kind,kyverno`, `STRICT=1`, `KEEP_CLUSTER=1`, `KIND_NODE_IMAGE`, `KYVERNO_POLICIES_REF`, `KYVERNO_POLICIES_CACHE`.
- `tests/psa-restricted/{psa-admission,kind-psa}.yaml` — kind cluster + PSA `AdmissionConfiguration` enforcing `restricted:latest` cluster-wide (kube-system exempted).
- `tests/psa-restricted/values-{baseline,restricted}.yaml` — scenario inputs.
- `tests/psa-restricted/README.md` — usage and design notes.
- `.github/workflows/psa-restricted.yml` — single job, both engines. Kyverno policies cached. Combined report → job summary.
- `.gitignore` — exclude local `psa-report/` output.

## Test plan

- [x] Local: `bash scripts/test-psa-restricted.sh` — produces the expected matrix; the one red cell is the documented `disallow-host-path` finding.
- [x] `helm lint charts/openmetadata` (unchanged) still passes.
- [ ] CI: this PR triggers the workflow; expected red until the chart-fix PR lands.

## Out of scope (separate PRs worth raising later)

1. **Chart fix** for the empty `volumes:` block (described above) — flips this PR's `restricted × kyverno` cell green.
2. **Multi-version matrix** over `kindest/node` minor versions — useful once the base is green, to catch PSS-version drift.
3. **Third scenario** covering ingestion-job pod templates with `seccompProfile: RuntimeDefault` set, once #506 (`seccompProfile in K8s config`) lands.