### PR TITLE
GEN-5352: Add Envoy Gateway support to OpenMetadata helm chart

### DIFF
--- a/charts/openmetadata/README.md
+++ b/charts/openmetadata/README.md
@@ -45,9 +45,43 @@ gateway:
       port: 443
 ```
 
-Optional `gateway.rules` let you configure advanced `matches`, `filters`, and explicit `backendRefs`.
+Optional `gateway.rules` let you configure advanced `matches`, `filters`, `backendRefs`, and per-rule `timeouts` (`request`/`backendRequest`).
 
 You can enable `gateway` alongside `ingress` during migration. Configure hostnames/listeners carefully to avoid duplicate external routing.
+
+### Envoy Gateway
+
+[Envoy Gateway](https://gateway.envoyproxy.io/) implements the Kubernetes Gateway API, so the `gateway.*` HTTPRoute above works as-is once you point `gateway.parentRefs` at an Envoy-managed `Gateway`:
+
+```yaml
+gateway:
+  enabled: true
+  hostnames:
+    - openmetadata.example.com
+  parentRefs:
+    - name: eg-gateway
+      namespace: envoy-gateway-system
+```
+
+For behavior that isn't part of the core Gateway API spec (session persistence, request buffer/body-size limits, retries, circuit breaking), Envoy Gateway exposes its own CRDs, `BackendTrafficPolicy` and `ClientTrafficPolicy` (`gateway.envoyproxy.io/v1alpha1`). This chart can create those too via `envoyGateway.backendTrafficPolicy` and `envoyGateway.clientTrafficPolicy`. The `spec` field under each is a raw passthrough merged next to `targetRefs`, since the exact fields depend on your installed Envoy Gateway version — check `https://gateway.envoyproxy.io/docs/api/extension_types/` for the version you have deployed before copying the example below verbatim:
+
+```yaml
+envoyGateway:
+  backendTrafficPolicy:
+    enabled: true
+    spec:
+      sessionPersistence:
+        type: Cookie
+        cookie:
+          name: http-cookie
+  clientTrafficPolicy:
+    enabled: true
+    spec:
+      connection:
+        bufferLimit: 500Mi
+```
+
+By default `backendTrafficPolicy` targets this chart's own `HTTPRoute` and `clientTrafficPolicy` targets `gateway.parentRefs[0]`; override `targetRefs` on either if you need to point elsewhere. Both require the Envoy Gateway CRDs to already be installed on the cluster.
 
 ---
 
@@ -305,6 +339,16 @@ You can enable `gateway` alongside `ingress` during migration. Configure hostnam
 | gateway.parentRefs[0].sectionName | string | `nil` |
 | gateway.parentRefs[0].port | int | `nil` |
 | gateway.rules | list | `[]` |
+| envoyGateway.backendTrafficPolicy.enabled | bool | `false` |
+| envoyGateway.backendTrafficPolicy.annotations | object | `{}` |
+| envoyGateway.backendTrafficPolicy.labels | object | `{}` |
+| envoyGateway.backendTrafficPolicy.targetRefs | list | `[]` |
+| envoyGateway.backendTrafficPolicy.spec | object | `{}` |
+| envoyGateway.clientTrafficPolicy.enabled | bool | `false` |
+| envoyGateway.clientTrafficPolicy.annotations | object | `{}` |
+| envoyGateway.clientTrafficPolicy.labels | object | `{}` |
+| envoyGateway.clientTrafficPolicy.targetRefs | list | `[]` |
+| envoyGateway.clientTrafficPolicy.spec | object | `{}` |
 | istio.annotations | object | `{}` |
 | istio.destinationRule.annotations | object | `{}` |
 | istio.destinationRule.enabled | bool | `false` |

--- a/charts/openmetadata/templates/NOTES.txt
+++ b/charts/openmetadata/templates/NOTES.txt
@@ -16,6 +16,9 @@
   Gateway API HTTPRoute has been created. Inspect `gateway.parentRefs` and your Gateway listeners to determine the external hostname.
 {{- end }}
 {{- end }}
+{{- if or .Values.envoyGateway.backendTrafficPolicy.enabled .Values.envoyGateway.clientTrafficPolicy.enabled }}
+  Envoy Gateway policy attachment(s) created ({{- if .Values.envoyGateway.backendTrafficPolicy.enabled }} BackendTrafficPolicy{{- end }}{{- if .Values.envoyGateway.clientTrafficPolicy.enabled }} ClientTrafficPolicy{{- end }} ). These only take effect if your Gateway is managed by Envoy Gateway.
+{{- end }}
 {{- if .Values.route.enabled }}
 {{- if .Values.route.host }}
   https://{{ .Values.route.host }}

--- a/charts/openmetadata/templates/envoygateway-backendtrafficpolicy.yaml
+++ b/charts/openmetadata/templates/envoygateway-backendtrafficpolicy.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.envoyGateway.backendTrafficPolicy.enabled }}
+{{- $fullName := include "OpenMetadata.fullname" . -}}
+{{- if not (.Capabilities.APIVersions.Has "gateway.envoyproxy.io/v1alpha1") }}
+{{- fail "envoyGateway.backendTrafficPolicy.enabled is true but gateway.envoyproxy.io/v1alpha1 is not available in the target cluster. Install Envoy Gateway's CRDs first." }}
+{{- end }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "OpenMetadata.labels" . | indent 4 }}
+    {{- with .Values.envoyGateway.backendTrafficPolicy.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.envoyGateway.backendTrafficPolicy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  targetRefs:
+    {{- if .Values.envoyGateway.backendTrafficPolicy.targetRefs }}
+    {{- toYaml .Values.envoyGateway.backendTrafficPolicy.targetRefs | nindent 4 }}
+    {{- else }}
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ $fullName }}
+    {{- end }}
+  {{- with .Values.envoyGateway.backendTrafficPolicy.spec }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/openmetadata/templates/envoygateway-clienttrafficpolicy.yaml
+++ b/charts/openmetadata/templates/envoygateway-clienttrafficpolicy.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.envoyGateway.clientTrafficPolicy.enabled }}
+{{- $fullName := include "OpenMetadata.fullname" . -}}
+{{- if not (.Capabilities.APIVersions.Has "gateway.envoyproxy.io/v1alpha1") }}
+{{- fail "envoyGateway.clientTrafficPolicy.enabled is true but gateway.envoyproxy.io/v1alpha1 is not available in the target cluster. Install Envoy Gateway's CRDs first." }}
+{{- end }}
+{{- $hasDefaultParentRef := and .Values.gateway.enabled (gt (len .Values.gateway.parentRefs) 0) (index .Values.gateway.parentRefs 0).name }}
+{{- if not (or .Values.envoyGateway.clientTrafficPolicy.targetRefs $hasDefaultParentRef) }}
+{{- fail "envoyGateway.clientTrafficPolicy.targetRefs is required unless gateway.enabled=true with gateway.parentRefs[0].name set" }}
+{{- end }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "OpenMetadata.labels" . | indent 4 }}
+    {{- with .Values.envoyGateway.clientTrafficPolicy.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.envoyGateway.clientTrafficPolicy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  targetRefs:
+    {{- if .Values.envoyGateway.clientTrafficPolicy.targetRefs }}
+    {{- toYaml .Values.envoyGateway.clientTrafficPolicy.targetRefs | nindent 4 }}
+    {{- else }}
+    {{- $ref := index .Values.gateway.parentRefs 0 }}
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ $ref.name }}
+    {{- end }}
+  {{- with .Values.envoyGateway.clientTrafficPolicy.spec }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/openmetadata/templates/gateway.yaml
+++ b/charts/openmetadata/templates/gateway.yaml
@@ -82,6 +82,10 @@ spec:
         - name: {{ $fullName | quote }}
           port: {{ $svcPort }}
         {{- end }}
+      {{- with .timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
     {{- else }}
     - matches:

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -1642,7 +1642,64 @@
                     }
                   }
                 }
+              },
+              "timeouts": {
+                "type": "object"
               }
+            }
+          }
+        }
+      }
+    },
+    "envoyGateway": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "backendTrafficPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "annotations": {
+              "type": "object"
+            },
+            "labels": {
+              "type": "object"
+            },
+            "targetRefs": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "spec": {
+              "type": "object"
+            }
+          }
+        },
+        "clientTrafficPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "annotations": {
+              "type": "object"
+            },
+            "labels": {
+              "type": "object"
+            },
+            "targetRefs": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "spec": {
+              "type": "object"
             }
           }
         }

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -561,6 +561,41 @@ gateway:
     #     - name: openmetadata
     #       port: 8585
     #       weight: 1
+    #   timeouts:
+    #     request: 300s
+    #     backendRequest: 300s
+
+# Envoy Gateway policy attachments — optional, on top of `gateway`. Envoy Gateway's
+# BackendTrafficPolicy/ClientTrafficPolicy CRDs (gateway.envoyproxy.io/v1alpha1) cover
+# things the core Gateway API spec doesn't (session persistence, buffer/body-size limits,
+# circuit breaking, etc). The `spec` field is a raw passthrough merged into the CRD's
+# spec alongside `targetRefs` — field names depend on your installed Envoy Gateway
+# version, see https://gateway.envoyproxy.io/docs/api/extension_types/
+envoyGateway:
+  # BackendTrafficPolicy — targets this chart's HTTPRoute by default.
+  backendTrafficPolicy:
+    enabled: false
+    annotations: {}
+    labels: {}
+    targetRefs: []
+      # - group: gateway.networking.k8s.io
+      #   kind: HTTPRoute
+      #   name: openmetadata
+    spec: {}
+      # sessionPersistence:
+      #   type: Cookie
+      #   cookie:
+      #     name: http-cookie
+  # ClientTrafficPolicy — targets the Gateway in `gateway.parentRefs[0]` by default.
+  clientTrafficPolicy:
+    enabled: false
+    annotations: {}
+    labels: {}
+    targetRefs: []
+      # - group: gateway.networking.k8s.io
+      #   kind: Gateway
+      #   name: shared-gateway
+    spec: {}
 
 # OpenShift Route — use instead of ingress when deploying on OpenShift.
 # Requires route.openshift.io/v1 API (available on all OpenShift clusters).


### PR DESCRIPTION
### What this PR does / why we need it :
Mercedes-Benz (BYOC, chart 1.12.12) is migrating from NGINX Ingress to Envoy Gateway on AKS and asked whether our chart forces them onto Ingress. 

The chart already has generic Gateway API support (#469, HTTPRoute via `gateway.*`), which covers basic routing since Envoy Gateway implements the Gateway API. This PR closes the remaining gap:

- `gateway.yaml`: adds a `timeouts` passthrough per HTTPRoute rule (Gateway API v1 core field) to cover request/backend timeouts.
- New optional `BackendTrafficPolicy` / `ClientTrafficPolicy` templates (`gateway.envoyproxy.io/v1alpha1`) for Envoy Gateway-specific behavior not in the core Gateway API spec (session persistence, buffer/body-size limits). Both are opt-in (`enabled: false` by default), guarded by an API-availability check, and use a raw `spec` passthrough since exact fields vary by installed Envoy Gateway version.
- README updated with an Envoy Gateway section and examples.
- Chart version bumped 1.12.13 -> 1.12.14.

GEN-5352

### Type of change :
- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Documentation

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] All new and existing tests passed.

### Reviewers
@akash-jain-10