### PR TITLE
openmetadata-dependencies: remove obsolete Airflow FAB downgrade

### DIFF
--- a/charts/deps/values.yaml
+++ b/charts/deps/values.yaml
@@ -108,11 +108,6 @@ airflow:
       value: ""
     - name: AIRFLOW__OPENMETADATA_SECRETS_MANAGER__AWS_ACCESS_KEY
       value: ""
-    # Workaround for Airflow 3 + MySQL compatibility issue
-    # Downgrade FAB provider to avoid CREATE INDEX IF NOT EXISTS issue
-    - name: _PIP_ADDITIONAL_REQUIREMENTS
-      value: "apache-airflow-providers-fab==2.4.4"
-
   # Create admin user
   createUserJob:
     # Whether the create user job should be created
@@ -195,7 +190,6 @@ airflow:
   redis:
     enabled: false
   # Configure external MySQL database
-  # Using downgraded FAB provider (2.4.4) to avoid CREATE INDEX IF NOT EXISTS issue
   data:
     metadataConnection:
       user: airflow_user


### PR DESCRIPTION
### What this PR does / why we need it

Removes the chart-level `_PIP_ADDITIONAL_REQUIREMENTS` override that installs `apache-airflow-providers-fab==2.4.4` whenever an Airflow pod starts.

The override was introduced for an older Airflow 3/MySQL migration concern. With the current 1.13.4 ingestion image, installing it changes the tested image dependency set from Airflow 3.3.0, FAB 3.7.1, and SQLAlchemy 2.0.51 to Airflow 3.1.8, FAB 2.4.4, and SQLAlchemy 1.4.54. The resulting SQLAlchemy downgrade prevents the OpenMetadata managed APIs plugin from importing.

The current FAB migration handles MySQL index creation directly, so the runtime downgrade is no longer required. This change also removes the stale comments describing the workaround.

Validation used the exact `docker.getcollate.io/openmetadata/ingestion:1.13.4` image configured by the chart. A populated FAB 2.4.4 database was upgraded on MySQL 8.0.37 with the unmodified image: the Airflow and FAB migration heads advanced, the Admin user and its 99 permission bindings were retained, the expected indexes were present, the managed APIs plugin loaded, and an idempotent migration rerun passed. `helm lint`, rendered-manifest verification, and `ct lint` also passed.

Related OpenMetadata reports:

- https://github.com/open-metadata/OpenMetadata/issues/29854
- https://github.com/open-metadata/OpenMetadata/issues/29482
- https://github.com/open-metadata/OpenMetadata/issues/29491

#
### Type of change

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Documentation

#
### Checklist

- [ ] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developer) document.
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] All new and existing tests passed.

#
### Reviewers

@tutte
