### PR TITLE
feat: support scheduling options for OMJob operator

### DIFF
--- a/charts/openmetadata/templates/omjob-operator-deployment.yaml
+++ b/charts/openmetadata/templates/omjob-operator-deployment.yaml
@@ -29,6 +29,18 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.omjobOperator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.omjobOperator.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.omjobOperator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: operator
         {{- with .Values.omjobOperator.securityContext }}

--- a/charts/openmetadata/values.schema.json
+++ b/charts/openmetadata/values.schema.json
@@ -2197,6 +2197,15 @@
             }
           }
         },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "affinity": {
+          "type": "object"
+        },
+        "tolerations": {
+          "type": "array"
+        },
         "podSecurityContext": {
           "type": "object"
         },

--- a/charts/openmetadata/values.yaml
+++ b/charts/openmetadata/values.yaml
@@ -829,6 +829,11 @@ omjobOperator:
     # - Leave empty for operator's own namespace only
     watchNamespaces: ""
 
+  # Schedule the operator pod on selected nodes.
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
   # Pod-level securityContext for the operator pod. Empty by default for
   # backwards compatibility. Required for clusters that enforce Pod
   # Security Standards "restricted".


### PR DESCRIPTION
## Summary

- Accept `omjobOperator.nodeSelector`, `omjobOperator.affinity`, and `omjobOperator.tolerations` in the chart schema.
- Render the scheduling options in the OMJob Operator Deployment pod spec.

Closes #522

## Validation

- `helm lint charts/openmetadata --set omjobOperator.enabled=true` with all three scheduling options configured
- `helm template` verified the rendered Deployment
- JSON schema parsing and `git diff --check` passed